### PR TITLE
Port tandoku markdown export from PowerShell to C#

### DIFF
--- a/scripts/TandokuInitEnvironment.ps1
+++ b/scripts/TandokuInitEnvironment.ps1
@@ -21,7 +21,7 @@ if (Test-Path $scriptsPath) {
     Write-Warning "Cannot find tandoku scripts path $scriptsPath"
 }
 
-$binPath = Join-Path (Split-Path $scriptsPath -Parent) 'src/Tandoku.CommandLine/bin/Debug/net9.0'
+$binPath = Join-Path (Split-Path $scriptsPath -Parent) 'src/Tandoku.CommandLine/bin/Debug/net10.0'
 if (Test-Path $binPath) {
     Write-Host "Adding tandoku bin path $binPath to PATH"
     $env:PATH = '{0}{1}{2}' -f $binPath,[IO.Path]::PathSeparator,$env:PATH

--- a/scripts/workflows/film.ps1
+++ b/scripts/workflows/film.ps1
@@ -156,7 +156,8 @@ tandoku content transform merge-ref-chunks $contentDirectory50 $mergeRefChunksCo
 $markdownPath = "$volumePath/markdown/$Configuration"
 
 # tandoku markdown export
-TandokuMarkdownExport $mergeRefChunksContentPath $markdownPath -NoHeadings -KeepTogether -RubyBehavior Html -ReferenceBehavior Footnotes -ReferenceLabels None -Quirks $config.markdownQuirks
+tandoku markdown export $mergeRefChunksContentPath $markdownPath --no-headings --keep-together --ruby html --ref-behavior footnotes --ref-labels none --quirks $config.markdownQuirks
+#TandokuMarkdownExport $mergeRefChunksContentPath $markdownPath -NoHeadings -KeepTogether -RubyBehavior Html -ReferenceBehavior Footnotes -ReferenceLabels None -Quirks $config.markdownQuirks
 
 if ($Target -like '*epub') {
     # epub artifact variables

--- a/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
+++ b/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
@@ -1,0 +1,91 @@
+﻿namespace Tandoku.CommandLine;
+
+using System.CommandLine;
+using Tandoku.Markdown;
+
+public sealed partial class Program
+{
+    private Command CreateMarkdownCommand() =>
+        new("markdown", "Commands for working with markdown derived from tandoku content")
+        {
+            this.CreateMarkdownExportCommand(),
+        };
+
+    private Command CreateMarkdownExportCommand()
+    {
+        var inputPathArgument = ArgumentFactory.InputPath();
+        var outputPathArgument = new Argument<string>("output-path")
+        {
+            Description = "Path of output directory or, when --combine is set, an output .md file",
+            Arity = ArgumentArity.ExactlyOne,
+        }.AcceptLegalFilePathsOnly();
+        var combineOption = new Option<bool>("--combine")
+        {
+            Description = "Combine all input content files into a single markdown file",
+        };
+        var noHeadingsOption = new Option<bool>("--no-headings")
+        {
+            Description = "Do not promote per-block notes/resources to headings",
+        };
+        var keepTogetherOption = new Option<bool>("--keep-together")
+        {
+            Description = "Wrap each block in a keep-together div",
+        };
+        var rubyOption = new Option<MarkdownRubyBehavior>("--ruby")
+        {
+            Description = "How ruby annotations should be rendered",
+            DefaultValueFactory = _ => MarkdownRubyBehavior.None,
+        };
+        var refBehaviorOption = new Option<MarkdownReferenceBehavior>("--ref-behavior")
+        {
+            Description = "How reference text should be rendered",
+            DefaultValueFactory = _ => MarkdownReferenceBehavior.None,
+        };
+        var refLabelsOption = new Option<MarkdownReferenceLabels>("--ref-labels")
+        {
+            Description = "Whether to render labels for references",
+            DefaultValueFactory = _ => MarkdownReferenceLabels.Default,
+        };
+        var quirksOption = new Option<MarkdownQuirks>("--quirks")
+        {
+            Description = "Reader-specific output quirks to apply",
+            DefaultValueFactory = _ => MarkdownQuirks.None,
+        };
+
+        var command = new Command("export", "Exports tandoku content to markdown")
+        {
+            inputPathArgument,
+            outputPathArgument,
+            combineOption,
+            noHeadingsOption,
+            keepTogetherOption,
+            rubyOption,
+            refBehaviorOption,
+            refLabelsOption,
+            quirksOption,
+        };
+
+        command.SetAction(async (parseResult, ct) =>
+        {
+            var inputPath = parseResult.GetRequiredValue(inputPathArgument);
+            var outputPath = parseResult.GetRequiredValue(outputPathArgument);
+            var options = new MarkdownExportOptions
+            {
+                Combine = parseResult.GetValue(combineOption),
+                NoHeadings = parseResult.GetValue(noHeadingsOption),
+                KeepTogether = parseResult.GetValue(keepTogetherOption),
+                RubyBehavior = parseResult.GetValue(rubyOption),
+                ReferenceBehavior = parseResult.GetValue(refBehaviorOption),
+                ReferenceLabels = parseResult.GetValue(refLabelsOption),
+                Quirks = parseResult.GetValue(quirksOption),
+            };
+
+            var exporter = new MarkdownExporter(options, this.fileSystem);
+            var written = await exporter.ExportAsync(inputPath.FullName, outputPath);
+            foreach (var file in written)
+                this.output.WriteLine($"Wrote {file}");
+        });
+
+        return command;
+    }
+}

--- a/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
+++ b/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
@@ -23,6 +23,8 @@ public sealed partial class Program
         {
             Description = "Combine all input content files into a single markdown file",
         };
+        // TODO - revisit naming/semantics; this is really "do not promote images to headings".
+        // Consider making this the default and adding a --heading-per-block (or similar) switch instead.
         var noHeadingsOption = new Option<bool>("--no-headings")
         {
             Description = "Do not promote per-block notes/resources to headings",
@@ -65,6 +67,10 @@ public sealed partial class Program
             quirksOption,
         };
 
+        // TODO - port -OutputPrefix from the PS script, or (preferred) introduce a general-purpose
+        // build task that applies a prefix to a set of files instead of baking it into export.
+        // TODO - integrate with version control: stage modified files in the output path so the user
+        // can run the command and diff against staged files. Add an opt-out switch for skipping VC.
         command.SetAction(async (parseResult, ct) =>
         {
             var inputPath = parseResult.GetRequiredValue(inputPathArgument);

--- a/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
+++ b/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
@@ -69,7 +69,7 @@ public sealed partial class Program
         {
             var inputPath = parseResult.GetRequiredValue(inputPathArgument);
             var outputPath = parseResult.GetRequiredValue(outputPathArgument);
-            var options = new MarkdownExportSettings
+            var settings = new MarkdownExportSettings
             {
                 Combine = parseResult.GetValue(combineOption),
                 NoHeadings = parseResult.GetValue(noHeadingsOption),
@@ -80,7 +80,7 @@ public sealed partial class Program
                 Quirks = parseResult.GetValue(quirksOption),
             };
 
-            var exporter = new MarkdownExporter(options, this.fileSystem);
+            var exporter = new MarkdownExporter(settings, this.fileSystem);
             var written = await exporter.ExportAsync(inputPath.FullName, outputPath);
             foreach (var file in written)
                 this.output.WriteLine($"Wrote {file}");

--- a/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
+++ b/src/Tandoku.CommandLine/Program.MarkdownCommands.cs
@@ -69,7 +69,7 @@ public sealed partial class Program
         {
             var inputPath = parseResult.GetRequiredValue(inputPathArgument);
             var outputPath = parseResult.GetRequiredValue(outputPathArgument);
-            var options = new MarkdownExportOptions
+            var options = new MarkdownExportSettings
             {
                 Combine = parseResult.GetValue(combineOption),
                 NoHeadings = parseResult.GetValue(noHeadingsOption),

--- a/src/Tandoku.CommandLine/Program.cs
+++ b/src/Tandoku.CommandLine/Program.cs
@@ -105,6 +105,7 @@ public sealed partial class Program
             this.CreateVolumeCommand(),
             this.CreateSourceCommand(),
             this.CreateContentCommand(),
+            this.CreateMarkdownCommand(),
             this.CreateSubtitlesCommand(),
         };
         rootCommand.Options.Add(this.jsonOutputOption);

--- a/src/Tandoku.CommandLine/Tandoku.CommandLine.csproj
+++ b/src/Tandoku.CommandLine/Tandoku.CommandLine.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Lucene.Net.Analysis.Kuromoji" Version="4.8.0-beta00016" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tandoku.Core/Markdown/MarkdownExportOptions.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExportOptions.cs
@@ -1,0 +1,47 @@
+﻿namespace Tandoku.Markdown;
+
+public enum MarkdownRubyBehavior
+{
+    None,
+    Html,
+    BlurHtml,
+    Remove,
+}
+
+public enum MarkdownReferenceBehavior
+{
+    None,
+    Footnotes,
+    BlurHtml,
+}
+
+public enum MarkdownReferenceLabels
+{
+    Default,
+    All,
+    None,
+}
+
+public enum MarkdownQuirks
+{
+    None,
+    KyBook3,
+}
+
+public sealed record MarkdownExportOptions
+{
+    public bool Combine { get; init; }
+    public bool NoHeadings { get; init; }
+    public bool KeepTogether { get; init; }
+    public MarkdownRubyBehavior RubyBehavior { get; init; }
+    public MarkdownReferenceBehavior ReferenceBehavior { get; init; }
+    public MarkdownReferenceLabels ReferenceLabels { get; init; }
+    public MarkdownQuirks Quirks { get; init; }
+
+    internal MarkdownRubyBehavior EffectiveRubyBehavior =>
+        // KyBook 3 does not support ruby rendering — drop *Html ruby behaviors back to None
+        this.Quirks == MarkdownQuirks.KyBook3 &&
+        (this.RubyBehavior == MarkdownRubyBehavior.Html || this.RubyBehavior == MarkdownRubyBehavior.BlurHtml)
+            ? MarkdownRubyBehavior.None
+            : this.RubyBehavior;
+}

--- a/src/Tandoku.Core/Markdown/MarkdownExportSettings.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExportSettings.cs
@@ -28,7 +28,7 @@ public enum MarkdownQuirks
     KyBook3,
 }
 
-public sealed record MarkdownExportOptions
+public sealed record MarkdownExportSettings
 {
     public bool Combine { get; init; }
     public bool NoHeadings { get; init; }

--- a/src/Tandoku.Core/Markdown/MarkdownExporter.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExporter.cs
@@ -86,13 +86,6 @@ public sealed partial class MarkdownExporter
         return written;
     }
 
-    public string ExportToString(IReadOnlyList<ContentBlock> blocks, string idPrefix, string? fileHeading = null)
-    {
-        var sb = new StringBuilder();
-        this.AppendBlocks(sb, blocks, idPrefix, fileHeading);
-        return sb.ToString();
-    }
-
     private static async Task<IReadOnlyList<ContentBlock>> ReadBlocksAsync(IFileInfo file)
     {
         var blocks = new List<ContentBlock>();
@@ -219,6 +212,7 @@ public sealed partial class MarkdownExporter
     {
         if (start is null)
             return null;
+
         // Match the PowerShell behavior of stripping fractional seconds
         return $"{(int)start.Value.TotalHours:00}:{start.Value.Minutes:00}:{start.Value.Seconds:00}";
     }

--- a/src/Tandoku.Core/Markdown/MarkdownExporter.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExporter.cs
@@ -23,11 +23,11 @@ public sealed class MarkdownExporter
     private static readonly Lazy<Template> BlockTemplate = new(LoadBlockTemplate);
 
     private readonly IFileSystem fileSystem;
-    private readonly MarkdownExportOptions options;
+    private readonly MarkdownExportSettings options;
 
-    public MarkdownExporter(MarkdownExportOptions? options = null, IFileSystem? fileSystem = null)
+    public MarkdownExporter(MarkdownExportSettings? options = null, IFileSystem? fileSystem = null)
     {
-        this.options = options ?? new MarkdownExportOptions();
+        this.options = options ?? new MarkdownExportSettings();
         this.fileSystem = fileSystem ?? new FileSystem();
     }
 

--- a/src/Tandoku.Core/Markdown/MarkdownExporter.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExporter.cs
@@ -1,24 +1,17 @@
 ﻿namespace Tandoku.Markdown;
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO.Abstractions;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using Markdig;
 using Scriban;
 using Scriban.Runtime;
 using Tandoku.Content;
 using Tandoku.Serialization;
 
-public sealed class MarkdownExporter
+public sealed partial class MarkdownExporter
 {
     private const string BlockTemplateResourceName = "Tandoku.Markdown.Templates.Block.scriban-md";
-
-    private static readonly Regex RubyPattern = new(
-        @"[ ]?(\w+)\[(\w+)\]",
-        RegexOptions.Compiled);
 
     private static readonly Lazy<Template> BlockTemplate = new(LoadBlockTemplate);
 
@@ -34,12 +27,12 @@ public sealed class MarkdownExporter
     public async Task<IReadOnlyList<string>> ExportAsync(string inputPath, string outputPath)
     {
         var inputDir = this.fileSystem.GetDirectory(inputPath);
-        var contentFiles = inputDir.EnumerateFilesByExtension(".content.yaml")
+        var contentFiles = inputDir.EnumerateContentFiles()
             .OrderBy(f => f.Name, this.fileSystem.Path.GetComparer())
             .ToList();
 
         if (contentFiles.Count == 0)
-            return Array.Empty<string>();
+            return [];
 
         var written = new List<string>();
 
@@ -67,7 +60,7 @@ public sealed class MarkdownExporter
             foreach (var contentFile in contentFiles)
             {
                 var blocks = await ReadBlocksAsync(contentFile);
-                AppendFile(sb, blocks, contentFile);
+                this.AppendFile(sb, blocks, contentFile);
             }
 
             await this.fileSystem.File.WriteAllTextAsync(combinedPath, sb.ToString());
@@ -83,7 +76,7 @@ public sealed class MarkdownExporter
 
                 var blocks = await ReadBlocksAsync(contentFile);
                 var sb = new StringBuilder();
-                AppendFile(sb, blocks, contentFile);
+                this.AppendFile(sb, blocks, contentFile);
 
                 await this.fileSystem.File.WriteAllTextAsync(target, sb.ToString());
                 written.Add(target);
@@ -96,7 +89,7 @@ public sealed class MarkdownExporter
     public string ExportToString(IReadOnlyList<ContentBlock> blocks, string idPrefix, string? fileHeading = null)
     {
         var sb = new StringBuilder();
-        AppendBlocks(sb, blocks, idPrefix, fileHeading);
+        this.AppendBlocks(sb, blocks, idPrefix, fileHeading);
         return sb.ToString();
     }
 
@@ -123,7 +116,7 @@ public sealed class MarkdownExporter
             fileHeading = idPrefix;
         }
 
-        AppendBlocks(sb, blocks, idPrefix, fileHeading);
+        this.AppendBlocks(sb, blocks, idPrefix, fileHeading);
     }
 
     private void AppendBlocks(StringBuilder sb, IReadOnlyList<ContentBlock> blocks, string idPrefix, string? fileHeading)
@@ -165,10 +158,10 @@ public sealed class MarkdownExporter
         }
 
         var media = new List<string>();
-        var imageMd = RenderMedia(block.Image?.Name, "images", heading);
+        var imageMd = this.RenderMedia(block.Image?.Name, "images", heading);
         if (imageMd is not null)
             media.Add(imageMd);
-        var audioMd = RenderMedia(block.Audio?.Name, "audio", heading);
+        var audioMd = this.RenderMedia(block.Audio?.Name, "audio", heading);
         if (audioMd is not null)
             media.Add(audioMd);
 
@@ -337,8 +330,8 @@ public sealed class MarkdownExporter
                     }
                     else
                     {
-                        char last = refSb.Length > 0 ? refSb[^1] : '\0';
-                        char prev = refSb.Length > 1 ? refSb[^2] : '\0';
+                        var last = refSb.Length > 0 ? refSb[^1] : '\0';
+                        var prev = refSb.Length > 1 ? refSb[^2] : '\0';
                         var sp = last == ' '
                             ? (prev == ' ' ? string.Empty : " ")
                             : "  ";
@@ -368,7 +361,7 @@ public sealed class MarkdownExporter
             _ => "$0",
         };
 
-        return RubyPattern.Replace(text, replacement);
+        return RubyPatternRegex().Replace(text, replacement);
     }
 
     internal static string ConvertTextToBlurHtml(string text, string id, bool ruby, string? label = null)
@@ -387,10 +380,9 @@ public sealed class MarkdownExporter
         var initial = $"<{element} class='{blurClass}'><input type='checkbox' id='{id}'/><label for='{id}'>";
         var final = $"</label></{element}>";
 
-        if (isPara)
-            html = Regex.Replace(html, "^<p>(.*)</p>$", $"{initial}$1{final}", RegexOptions.Singleline);
-        else
-            html = $"{initial}{html}{final}";
+        html = isPara ?
+            HtmlParagraphRegex().Replace(html, $"{initial}$1{final}") :
+            $"{initial}{html}{final}";
 
         if (label is not null)
             html = $"<p><span>{label}:</span> {html}</p>";
@@ -416,9 +408,9 @@ public sealed class MarkdownExporter
         using var reader = new StreamReader(stream);
         var source = reader.ReadToEnd();
         var template = Template.Parse(source);
-        if (template.HasErrors)
-            throw new InvalidOperationException("Failed to parse block template: " + string.Join("; ", template.Messages));
-        return template;
+        return template.HasErrors ?
+            throw new InvalidOperationException("Failed to parse block template: " + string.Join("; ", template.Messages)) :
+            template;
     }
 
     private sealed class BlockModel
@@ -426,9 +418,9 @@ public sealed class MarkdownExporter
         public bool KeepTogether { get; init; }
         public string? Heading { get; init; }
         public string? SectionHeading { get; init; }
-        public IReadOnlyList<string> MediaBlocks { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<string> MediaBlocks { get; init; } = [];
         public bool SuppressBlankAfterMedia { get; init; }
-        public IReadOnlyList<ChunkModel> Chunks { get; init; } = Array.Empty<ChunkModel>();
+        public IReadOnlyList<ChunkModel> Chunks { get; init; } = [];
     }
 
     private sealed class ChunkModel
@@ -436,4 +428,9 @@ public sealed class MarkdownExporter
         public string Text { get; init; } = string.Empty;
         public string? RefText { get; init; }
     }
+
+    [GeneratedRegex(@"[ ]?(\w+)\[(\w+)\]")]
+    private static partial Regex RubyPatternRegex();
+    [GeneratedRegex("^<p>(.*)</p>$", RegexOptions.Singleline)]
+    private static partial Regex HtmlParagraphRegex();
 }

--- a/src/Tandoku.Core/Markdown/MarkdownExporter.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExporter.cs
@@ -123,7 +123,7 @@ public sealed class MarkdownExporter
             fileHeading = idPrefix;
         }
 
-        AppendBlocks(sb, blocks, idPrefix!, fileHeading);
+        AppendBlocks(sb, blocks, idPrefix, fileHeading);
     }
 
     private void AppendBlocks(StringBuilder sb, IReadOnlyList<ContentBlock> blocks, string idPrefix, string? fileHeading)

--- a/src/Tandoku.Core/Markdown/MarkdownExporter.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExporter.cs
@@ -23,11 +23,11 @@ public sealed class MarkdownExporter
     private static readonly Lazy<Template> BlockTemplate = new(LoadBlockTemplate);
 
     private readonly IFileSystem fileSystem;
-    private readonly MarkdownExportSettings options;
+    private readonly MarkdownExportSettings settings;
 
-    public MarkdownExporter(MarkdownExportSettings? options = null, IFileSystem? fileSystem = null)
+    public MarkdownExporter(MarkdownExportSettings? settings = null, IFileSystem? fileSystem = null)
     {
-        this.options = options ?? new MarkdownExportSettings();
+        this.settings = settings ?? new MarkdownExportSettings();
         this.fileSystem = fileSystem ?? new FileSystem();
     }
 
@@ -43,7 +43,7 @@ public sealed class MarkdownExporter
 
         var written = new List<string>();
 
-        if (this.options.Combine)
+        if (this.settings.Combine)
         {
             string combinedPath;
             string targetDirectory;
@@ -115,7 +115,7 @@ public sealed class MarkdownExporter
             // Default id prefix - blockId may be used in HTML id attributes which must start with a letter
             idPrefix = "block";
         }
-        else if (this.options.NoHeadings)
+        else if (this.settings.NoHeadings)
         {
             fileHeading = idPrefix;
         }
@@ -125,7 +125,7 @@ public sealed class MarkdownExporter
 
     private void AppendBlocks(StringBuilder sb, IReadOnlyList<ContentBlock> blocks, string idPrefix, string? fileHeading)
     {
-        if (this.options.NoHeadings && !string.IsNullOrEmpty(fileHeading))
+        if (this.settings.NoHeadings && !string.IsNullOrEmpty(fileHeading))
         {
             sb.Append("# ").Append(fileHeading).Append('\n').Append('\n');
         }
@@ -153,7 +153,7 @@ public sealed class MarkdownExporter
     private BlockModel BuildBlockModel(ContentBlock block, int blockIndex, string blockId)
     {
         var heading = GetHeading(block);
-        var showHeading = !string.IsNullOrEmpty(heading) && !this.options.NoHeadings;
+        var showHeading = !string.IsNullOrEmpty(heading) && !this.settings.NoHeadings;
         string? sectionHeading = null;
         if (!showHeading && blockIndex % 50 == 0)
         {
@@ -195,11 +195,11 @@ public sealed class MarkdownExporter
 
         return new BlockModel
         {
-            KeepTogether = this.options.KeepTogether,
+            KeepTogether = this.settings.KeepTogether,
             Heading = showHeading ? heading : null,
             SectionHeading = sectionHeading,
             MediaBlocks = media,
-            SuppressBlankAfterMedia = this.options.Quirks == MarkdownQuirks.KyBook3,
+            SuppressBlankAfterMedia = this.settings.Quirks == MarkdownQuirks.KyBook3,
             Chunks = chunks,
         };
     }
@@ -231,13 +231,13 @@ public sealed class MarkdownExporter
 
         var encoded = Uri.EscapeDataString(media).Replace("%2F", "/", StringComparison.Ordinal);
         var url = $"{container}/{encoded}";
-        var suffix = this.options.Quirks == MarkdownQuirks.KyBook3 ? "  " : string.Empty;
+        var suffix = this.settings.Quirks == MarkdownQuirks.KyBook3 ? "  " : string.Empty;
 
         if (container == "audio")
         {
             // Use explicit <audio> tag because the anchor link that pandoc embeds within the <audio> tag
             // if ![]() is used fails EPUB3 validation and causes issues for KyBook 3 on iOS
-            var controls = this.options.Quirks == MarkdownQuirks.KyBook3 ? "controls" : string.Empty;
+            var controls = this.settings.Quirks == MarkdownQuirks.KyBook3 ? "controls" : string.Empty;
             return $"<audio src=\"{url}\" controls=\"{controls}\"></audio>{suffix}";
         }
 
@@ -246,14 +246,14 @@ public sealed class MarkdownExporter
 
     private ChunkModel BuildChunkModel(ContentBlockChunk chunk, string chunkId)
     {
-        var ruby = this.options.EffectiveRubyBehavior;
+        var ruby = this.settings.EffectiveRubyBehavior;
         var chunkText = ProcessRubyText(chunk.Text ?? string.Empty, ruby);
         if (ruby == MarkdownRubyBehavior.BlurHtml)
             chunkText = ConvertTextToBlurHtml(chunkText, chunkId, ruby: true);
 
         var refSb = new StringBuilder();
-        var refLabels = (chunk.References.Count > 1 || this.options.ReferenceLabels == MarkdownReferenceLabels.All) &&
-            this.options.ReferenceLabels != MarkdownReferenceLabels.None;
+        var refLabels = (chunk.References.Count > 1 || this.settings.ReferenceLabels == MarkdownReferenceLabels.All) &&
+            this.settings.ReferenceLabels != MarkdownReferenceLabels.None;
 
         foreach (var (refName, refValue) in chunk.References.OrderBy(kv => kv.Key, StringComparer.Ordinal))
         {
@@ -261,7 +261,7 @@ public sealed class MarkdownExporter
             if (string.IsNullOrEmpty(refText))
                 continue;
 
-            switch (this.options.ReferenceBehavior)
+            switch (this.settings.ReferenceBehavior)
             {
                 case MarkdownReferenceBehavior.Footnotes:
                 {
@@ -310,12 +310,12 @@ public sealed class MarkdownExporter
             refSb.Append('\n');
         }
 
-        if (this.options.ReferenceBehavior == MarkdownReferenceBehavior.Footnotes && refSb.Length > 0)
+        if (this.settings.ReferenceBehavior == MarkdownReferenceBehavior.Footnotes && refSb.Length > 0)
         {
             chunkText = $"{chunkText} [^{chunkId}]";
             refSb.Insert(0, $"[^{chunkId}]: ");
 
-            if (this.options.Quirks == MarkdownQuirks.KyBook3)
+            if (this.settings.Quirks == MarkdownQuirks.KyBook3)
             {
                 // Convert paragraphs to line breaks for KyBook 3 as paragraphs in footnotes are not rendered properly
                 var lines = StringToLines(refSb.ToString().TrimEnd());

--- a/src/Tandoku.Core/Markdown/MarkdownExporter.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExporter.cs
@@ -55,6 +55,8 @@ public sealed class MarkdownExporter
             else
             {
                 targetDirectory = outputPath;
+                // TODO - consider exposing the combined output filename as a property on volume info
+                // (and possibly drop the moniker, just using the cleaned title)
                 combinedPath = this.fileSystem.Path.Combine(outputPath, "content.md");
             }
 
@@ -117,6 +119,7 @@ public sealed class MarkdownExporter
         }
         else if (this.settings.NoHeadings)
         {
+            // TODO - clean up naming; consider including the file heading even when writing block headings
             fileHeading = idPrefix;
         }
 
@@ -157,6 +160,7 @@ public sealed class MarkdownExporter
         string? sectionHeading = null;
         if (!showHeading && blockIndex % 50 == 0)
         {
+            // TODO - clean this up alongside heading styling overall
             sectionHeading = FormatTimecode(block.Source?.Timecodes?.Start);
         }
 
@@ -171,7 +175,9 @@ public sealed class MarkdownExporter
         var chunks = new List<ChunkModel>();
         if (block.Chunks.Count > 0)
         {
-            // Inject formatted timecode as additional reference if there are existing references on the last chunk
+            // Inject formatted timecode as additional reference if there are existing references on the last chunk.
+            // TODO - make this an option or a separate transform (how much 'formatting' should be done in content files?)
+            // Currently only injecting timecode if there are other references (to avoid footnotes that would only have a timecode).
             var processedChunks = block.Chunks;
             var timecode = FormatTimecode(block.Source?.Timecodes?.Start);
             if (timecode is not null && block.Chunks.Any(c => c.References.Count > 0))
@@ -295,6 +301,7 @@ public sealed class MarkdownExporter
                 default:
                     if (refLabels)
                     {
+                        // TODO - indentation as separate style?
                         var lines = StringToLines(refText);
                         if (lines.Count > 0)
                             lines[0] = $"{refName}: {lines[0]}";

--- a/src/Tandoku.Core/Markdown/MarkdownExporter.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExporter.cs
@@ -1,0 +1,432 @@
+﻿namespace Tandoku.Markdown;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO.Abstractions;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Markdig;
+using Scriban;
+using Scriban.Runtime;
+using Tandoku.Content;
+using Tandoku.Serialization;
+
+public sealed class MarkdownExporter
+{
+    private const string BlockTemplateResourceName = "Tandoku.Markdown.Templates.Block.scriban-md";
+
+    private static readonly Regex RubyPattern = new(
+        @"[ ]?(\w+)\[(\w+)\]",
+        RegexOptions.Compiled);
+
+    private static readonly Lazy<Template> BlockTemplate = new(LoadBlockTemplate);
+
+    private readonly IFileSystem fileSystem;
+    private readonly MarkdownExportOptions options;
+
+    public MarkdownExporter(MarkdownExportOptions? options = null, IFileSystem? fileSystem = null)
+    {
+        this.options = options ?? new MarkdownExportOptions();
+        this.fileSystem = fileSystem ?? new FileSystem();
+    }
+
+    public async Task<IReadOnlyList<string>> ExportAsync(string inputPath, string outputPath)
+    {
+        var inputDir = this.fileSystem.GetDirectory(inputPath);
+        var contentFiles = inputDir.EnumerateFilesByExtension(".content.yaml")
+            .OrderBy(f => f.Name, this.fileSystem.Path.GetComparer())
+            .ToList();
+
+        if (contentFiles.Count == 0)
+            return Array.Empty<string>();
+
+        var written = new List<string>();
+
+        if (this.options.Combine)
+        {
+            string combinedPath;
+            string targetDirectory;
+            if (outputPath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                combinedPath = outputPath;
+                targetDirectory = this.fileSystem.Path.GetDirectoryName(outputPath) ?? string.Empty;
+            }
+            else
+            {
+                targetDirectory = outputPath;
+                combinedPath = this.fileSystem.Path.Combine(outputPath, "content.md");
+            }
+
+            if (!string.IsNullOrEmpty(targetDirectory))
+                this.fileSystem.GetDirectory(targetDirectory).Create();
+
+            var sb = new StringBuilder();
+            foreach (var contentFile in contentFiles)
+            {
+                var blocks = await ReadBlocksAsync(contentFile);
+                AppendFile(sb, blocks, contentFile);
+            }
+
+            await this.fileSystem.File.WriteAllTextAsync(combinedPath, sb.ToString());
+            written.Add(combinedPath);
+        }
+        else
+        {
+            this.fileSystem.GetDirectory(outputPath).Create();
+            foreach (var contentFile in contentFiles)
+            {
+                var baseName = this.fileSystem.Path.GetBaseName(contentFile.Name) ?? "content";
+                var target = this.fileSystem.Path.Combine(outputPath, baseName + ".md");
+
+                var blocks = await ReadBlocksAsync(contentFile);
+                var sb = new StringBuilder();
+                AppendFile(sb, blocks, contentFile);
+
+                await this.fileSystem.File.WriteAllTextAsync(target, sb.ToString());
+                written.Add(target);
+            }
+        }
+
+        return written;
+    }
+
+    public string ExportToString(IReadOnlyList<ContentBlock> blocks, string idPrefix, string? fileHeading = null)
+    {
+        var sb = new StringBuilder();
+        AppendBlocks(sb, blocks, idPrefix, fileHeading);
+        return sb.ToString();
+    }
+
+    private static async Task<IReadOnlyList<ContentBlock>> ReadBlocksAsync(IFileInfo file)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in YamlSerializer.ReadStreamAsync<ContentBlock>(file))
+            blocks.Add(block);
+        return blocks;
+    }
+
+    private void AppendFile(StringBuilder sb, IReadOnlyList<ContentBlock> blocks, IFileInfo file)
+    {
+        var idPrefix = this.fileSystem.Path.GetBaseName(file.Name);
+        string? fileHeading = null;
+        if (string.IsNullOrEmpty(idPrefix))
+        {
+            // Default id prefix - blockId may be used in HTML id attributes which must start with a letter
+            idPrefix = "block";
+        }
+        else if (this.options.NoHeadings)
+        {
+            fileHeading = idPrefix;
+        }
+
+        AppendBlocks(sb, blocks, idPrefix!, fileHeading);
+    }
+
+    private void AppendBlocks(StringBuilder sb, IReadOnlyList<ContentBlock> blocks, string idPrefix, string? fileHeading)
+    {
+        if (this.options.NoHeadings && !string.IsNullOrEmpty(fileHeading))
+        {
+            sb.Append("# ").Append(fileHeading).Append('\n').Append('\n');
+        }
+
+        for (var i = 0; i < blocks.Count; i++)
+        {
+            var blockIndex = i + 1;
+            var block = blocks[i];
+            var blockId = $"{idPrefix}-{blockIndex}";
+            var model = this.BuildBlockModel(block, blockIndex, blockId);
+            RenderBlock(sb, model);
+        }
+    }
+
+    private static void RenderBlock(StringBuilder sb, BlockModel model)
+    {
+        var scriptObject = new ScriptObject();
+        scriptObject.Import(model);
+        var context = new TemplateContext { StrictVariables = false, NewLine = "\n" };
+        context.PushGlobal(scriptObject);
+        var output = BlockTemplate.Value.Render(context);
+        sb.Append(output);
+    }
+
+    private BlockModel BuildBlockModel(ContentBlock block, int blockIndex, string blockId)
+    {
+        var heading = GetHeading(block);
+        var showHeading = !string.IsNullOrEmpty(heading) && !this.options.NoHeadings;
+        string? sectionHeading = null;
+        if (!showHeading && blockIndex % 50 == 0)
+        {
+            sectionHeading = FormatTimecode(block.Source?.Timecodes?.Start);
+        }
+
+        var media = new List<string>();
+        var imageMd = RenderMedia(block.Image?.Name, "images", heading);
+        if (imageMd is not null)
+            media.Add(imageMd);
+        var audioMd = RenderMedia(block.Audio?.Name, "audio", heading);
+        if (audioMd is not null)
+            media.Add(audioMd);
+
+        var chunks = new List<ChunkModel>();
+        if (block.Chunks.Count > 0)
+        {
+            // Inject formatted timecode as additional reference if there are existing references on the last chunk
+            var processedChunks = block.Chunks;
+            var timecode = FormatTimecode(block.Source?.Timecodes?.Start);
+            if (timecode is not null && block.Chunks.Any(c => c.References.Count > 0))
+            {
+                var last = block.Chunks[^1];
+                var newRefs = last.References.SetItem("time", new Chunk { Text = timecode });
+                var updated = last with { References = newRefs };
+                processedChunks = block.Chunks.SetItem(block.Chunks.Count - 1, new ContentBlockChunk(updated)
+                {
+                    References = newRefs,
+                });
+            }
+
+            for (var i = 0; i < processedChunks.Count; i++)
+            {
+                var chunk = processedChunks[i];
+                var chunkId = processedChunks.Count > 1 ? $"{blockId}-{i + 1}" : blockId;
+                chunks.Add(this.BuildChunkModel(chunk, chunkId));
+            }
+        }
+
+        return new BlockModel
+        {
+            KeepTogether = this.options.KeepTogether,
+            Heading = showHeading ? heading : null,
+            SectionHeading = sectionHeading,
+            MediaBlocks = media,
+            SuppressBlankAfterMedia = this.options.Quirks == MarkdownQuirks.KyBook3,
+            Chunks = chunks,
+        };
+    }
+
+    private static string? GetHeading(ContentBlock block)
+    {
+        var heading = block.Source?.Note ?? block.Source?.Resource;
+        if (!string.IsNullOrEmpty(heading))
+            return heading;
+
+        if (!string.IsNullOrEmpty(block.Image?.Name))
+            return Path.GetFileNameWithoutExtension(block.Image.Name);
+
+        return null;
+    }
+
+    private static string? FormatTimecode(TimeSpan? start)
+    {
+        if (start is null)
+            return null;
+        // Match the PowerShell behavior of stripping fractional seconds
+        return $"{(int)start.Value.TotalHours:00}:{start.Value.Minutes:00}:{start.Value.Seconds:00}";
+    }
+
+    private string? RenderMedia(string? media, string container, string? caption)
+    {
+        if (string.IsNullOrEmpty(media))
+            return null;
+
+        var encoded = Uri.EscapeDataString(media).Replace("%2F", "/", StringComparison.Ordinal);
+        var url = $"{container}/{encoded}";
+        var suffix = this.options.Quirks == MarkdownQuirks.KyBook3 ? "  " : string.Empty;
+
+        if (container == "audio")
+        {
+            // Use explicit <audio> tag because the anchor link that pandoc embeds within the <audio> tag
+            // if ![]() is used fails EPUB3 validation and causes issues for KyBook 3 on iOS
+            var controls = this.options.Quirks == MarkdownQuirks.KyBook3 ? "controls" : string.Empty;
+            return $"<audio src=\"{url}\" controls=\"{controls}\"></audio>{suffix}";
+        }
+
+        return $"![{caption}]({url}){suffix}";
+    }
+
+    private ChunkModel BuildChunkModel(ContentBlockChunk chunk, string chunkId)
+    {
+        var ruby = this.options.EffectiveRubyBehavior;
+        var chunkText = ProcessRubyText(chunk.Text ?? string.Empty, ruby);
+        if (ruby == MarkdownRubyBehavior.BlurHtml)
+            chunkText = ConvertTextToBlurHtml(chunkText, chunkId, ruby: true);
+
+        var refSb = new StringBuilder();
+        var refLabels = (chunk.References.Count > 1 || this.options.ReferenceLabels == MarkdownReferenceLabels.All) &&
+            this.options.ReferenceLabels != MarkdownReferenceLabels.None;
+
+        foreach (var (refName, refValue) in chunk.References.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            var refText = refValue.Text;
+            if (string.IsNullOrEmpty(refText))
+                continue;
+
+            switch (this.options.ReferenceBehavior)
+            {
+                case MarkdownReferenceBehavior.Footnotes:
+                {
+                    var lines = StringToLines(refText);
+                    for (var i = 0; i < lines.Count; i++)
+                    {
+                        var line = lines[i];
+                        if (line.Length > 0)
+                        {
+                            if (refSb.Length > 0)
+                                refSb.Append("    ");
+                            if (refLabels && i == 0)
+                                refSb.Append(refName).Append(": ").Append(line).Append('\n');
+                            else
+                                refSb.Append(line).Append('\n');
+                        }
+                        else
+                        {
+                            refSb.Append('\n');
+                        }
+                    }
+                    refText = null;
+                    break;
+                }
+                case MarkdownReferenceBehavior.BlurHtml:
+                {
+                    var refId = $"{chunkId}-ref-{refName}";
+                    refText = ConvertTextToBlurHtml(refText, refId, ruby: false, label: refLabels ? refName : null);
+                    break;
+                }
+                default:
+                    if (refLabels)
+                    {
+                        var lines = StringToLines(refText);
+                        if (lines.Count > 0)
+                            lines[0] = $"{refName}: {lines[0]}";
+                        foreach (var line in lines)
+                            refSb.Append("> ").Append(line).Append('\n');
+                        refText = null;
+                    }
+                    break;
+            }
+
+            if (refText is not null)
+                refSb.Append(refText).Append('\n');
+            refSb.Append('\n');
+        }
+
+        if (this.options.ReferenceBehavior == MarkdownReferenceBehavior.Footnotes && refSb.Length > 0)
+        {
+            chunkText = $"{chunkText} [^{chunkId}]";
+            refSb.Insert(0, $"[^{chunkId}]: ");
+
+            if (this.options.Quirks == MarkdownQuirks.KyBook3)
+            {
+                // Convert paragraphs to line breaks for KyBook 3 as paragraphs in footnotes are not rendered properly
+                var lines = StringToLines(refSb.ToString().TrimEnd());
+                refSb.Clear();
+                foreach (var line in lines)
+                {
+                    if (line.Length > 0)
+                    {
+                        if (refSb.Length > 0)
+                            refSb.Append('\n');
+                        refSb.Append(line);
+                    }
+                    else
+                    {
+                        char last = refSb.Length > 0 ? refSb[^1] : '\0';
+                        char prev = refSb.Length > 1 ? refSb[^2] : '\0';
+                        var sp = last == ' '
+                            ? (prev == ' ' ? string.Empty : " ")
+                            : "  ";
+                        refSb.Append(sp);
+                    }
+                }
+                refSb.Append('\n');
+            }
+        }
+
+        return new ChunkModel
+        {
+            Text = chunkText,
+            RefText = refSb.Length > 0 ? refSb.ToString() : null,
+        };
+    }
+
+    internal static string ProcessRubyText(string text, MarkdownRubyBehavior ruby)
+    {
+        if (ruby == MarkdownRubyBehavior.None)
+            return text;
+
+        var replacement = ruby switch
+        {
+            MarkdownRubyBehavior.Html or MarkdownRubyBehavior.BlurHtml => "<ruby>$1<rt>$2</rt></ruby>",
+            MarkdownRubyBehavior.Remove => "$1",
+            _ => "$0",
+        };
+
+        return RubyPattern.Replace(text, replacement);
+    }
+
+    internal static string ConvertTextToBlurHtml(string text, string id, bool ruby, string? label = null)
+    {
+        if (ruby && !text.Contains("<ruby>", StringComparison.Ordinal))
+        {
+            return label is not null ? $"{label}: {text}" : text;
+        }
+
+        var html = Markdig.Markdown.ToHtml(text).TrimEnd();
+        var isPara = html.StartsWith("<p>", StringComparison.Ordinal) &&
+            html.EndsWith("</p>", StringComparison.Ordinal);
+        var element = isPara ? (label is not null ? "span" : "p") : "div";
+
+        var blurClass = ruby ? "blurRuby" : "blurText";
+        var initial = $"<{element} class='{blurClass}'><input type='checkbox' id='{id}'/><label for='{id}'>";
+        var final = $"</label></{element}>";
+
+        if (isPara)
+            html = Regex.Replace(html, "^<p>(.*)</p>$", $"{initial}$1{final}", RegexOptions.Singleline);
+        else
+            html = $"{initial}{html}{final}";
+
+        if (label is not null)
+            html = $"<p><span>{label}:</span> {html}</p>";
+
+        return html;
+    }
+
+    private static List<string> StringToLines(string s)
+    {
+        var lines = new List<string>();
+        using var reader = new StringReader(s);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+            lines.Add(line);
+        return lines;
+    }
+
+    private static Template LoadBlockTemplate()
+    {
+        using var stream = typeof(MarkdownExporter).Assembly
+            .GetManifestResourceStream(BlockTemplateResourceName)
+            ?? throw new InvalidOperationException($"Embedded resource '{BlockTemplateResourceName}' not found.");
+        using var reader = new StreamReader(stream);
+        var source = reader.ReadToEnd();
+        var template = Template.Parse(source);
+        if (template.HasErrors)
+            throw new InvalidOperationException("Failed to parse block template: " + string.Join("; ", template.Messages));
+        return template;
+    }
+
+    private sealed class BlockModel
+    {
+        public bool KeepTogether { get; init; }
+        public string? Heading { get; init; }
+        public string? SectionHeading { get; init; }
+        public IReadOnlyList<string> MediaBlocks { get; init; } = Array.Empty<string>();
+        public bool SuppressBlankAfterMedia { get; init; }
+        public IReadOnlyList<ChunkModel> Chunks { get; init; } = Array.Empty<ChunkModel>();
+    }
+
+    private sealed class ChunkModel
+    {
+        public string Text { get; init; } = string.Empty;
+        public string? RefText { get; init; }
+    }
+}

--- a/src/Tandoku.Core/Markdown/MarkdownExtensions.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExtensions.cs
@@ -24,7 +24,7 @@ internal static class MarkdownExtensions
     public static IMarkdownText CombineText(this IEnumerable<IMarkdownText?> markdownTexts, MarkdownSeparator separator) =>
         new MarkdownText(string.Join(
             SepToString(separator),
-            markdownTexts.Where(t => !string.IsNullOrWhiteSpace(t?.Text)).Select(t => t!.Text)));
+            markdownTexts.Select(t => t?.Text).Where(t => !string.IsNullOrWhiteSpace(t))));
 
     internal static string ToMarkdownString(this MarkdownObject md, NormalizeOptions? options = null)
     {

--- a/src/Tandoku.Core/Markdown/MarkdownExtensions.cs
+++ b/src/Tandoku.Core/Markdown/MarkdownExtensions.cs
@@ -19,7 +19,7 @@ public enum MarkdownSeparator
 internal static class MarkdownExtensions
 {
     public static string? ToPlainText(this IMarkdownText markdownText) =>
-        markdownText.Text is not null ? Markdown.ToPlainText(markdownText.Text) : null;
+        markdownText.Text is not null ? Markdig.Markdown.ToPlainText(markdownText.Text) : null;
 
     public static IMarkdownText CombineText(this IEnumerable<IMarkdownText?> markdownTexts, MarkdownSeparator separator) =>
         new MarkdownText(string.Join(

--- a/src/Tandoku.Core/Markdown/Templates/Block.scriban-md
+++ b/src/Tandoku.Core/Markdown/Templates/Block.scriban-md
@@ -1,0 +1,25 @@
+{{- capture out -}}
+{{ if keep_together }}::: {.keep-together}
+{{ end -}}
+{{ if heading }}# {{ heading }}
+
+{{ end -}}
+{{ if section_heading }}## {{ section_heading }}
+{{ end -}}
+{{ for media in media_blocks -}}
+{{ media }}
+{{ if !suppress_blank_after_media }}
+{{ end -}}
+{{ end -}}
+{{ for chunk in chunks -}}
+{{ chunk.text }}
+
+{{ if chunk.ref_text -}}
+{{ chunk.ref_text }}
+{{ end -}}
+{{ end -}}
+{{ if keep_together }}:::
+
+{{ end -}}
+{{- end -}}
+{{- out -}}

--- a/src/Tandoku.Core/Tandoku.Core.csproj
+++ b/src/Tandoku.Core/Tandoku.Core.csproj
@@ -25,6 +25,10 @@
     <PackageReference Include="Lucene.Net.Analysis.Kuromoji" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
     <PackageReference Include="Markdig" Version="0.38.0" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Scriban" Version="7.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="SubtitlesParser" Version="1.5.1" />

--- a/src/Tandoku.Core/Tandoku.Core.csproj
+++ b/src/Tandoku.Core/Tandoku.Core.csproj
@@ -12,6 +12,11 @@
     <CodeAnalysisRuleSet>..\..\tandoku.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Markdown\Templates\*.scriban-md">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="libse" Version="4.0.8" />
     <PackageReference Include="LiteDb" Version="5.0.21" />
@@ -20,6 +25,7 @@
     <PackageReference Include="Lucene.Net.Analysis.Kuromoji" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
     <PackageReference Include="Markdig" Version="0.38.0" />
+    <PackageReference Include="Scriban" Version="7.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="SubtitlesParser" Version="1.5.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="21.0.29" />

--- a/tests/Tandoku.CommandLine.Tests/CliTestBase.cs
+++ b/tests/Tandoku.CommandLine.Tests/CliTestBase.cs
@@ -5,7 +5,7 @@ using System.IO.Abstractions.TestingHelpers;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
-public abstract class CliTestBase
+public abstract class CliTestBase : IDisposable
 {
     protected readonly StringWriter outputWriter;
     protected readonly StringWriter errorWriter;
@@ -28,6 +28,13 @@ public abstract class CliTestBase
         // later in order to allow for mock file system to properly support validation.
         this.baseDirectory = this.fileSystem.GetDirectory(Directory.GetCurrentDirectory());
         this.fileSystem.Directory.SetCurrentDirectory(this.baseDirectory.FullName);
+    }
+
+    public void Dispose()
+    {
+        // This isn't really needed but keeping TUnit happy
+        this.outputWriter.Dispose();
+        this.errorWriter.Dispose();
     }
 
     protected async Task RunAndAssertAsync(

--- a/tests/Tandoku.CommandLine.Tests/MarkdownCommandTests.cs
+++ b/tests/Tandoku.CommandLine.Tests/MarkdownCommandTests.cs
@@ -1,0 +1,47 @@
+﻿namespace Tandoku.CommandLine.Tests;
+
+using System.IO.Abstractions.TestingHelpers;
+
+public class MarkdownCommandTests : CliTestBase
+{
+    private const string SampleContent =
+        "source:\n" +
+        "  note: Opening\n" +
+        "chunks:\n" +
+        "- text: |-\n" +
+        "    むかし[むかし]、ある所にお爺さんとお婆さんが住んでいました。\n" +
+        "  references:\n" +
+        "    en:\n" +
+        "      text: Once upon a time.\n";
+
+    [Test]
+    public async Task Export_WritesPerFileMarkdown()
+    {
+        var inputDir = this.fileSystem.GetCurrentDirectory().CreateSubdirectory("in");
+        var outDir = this.fileSystem.GetCurrentDirectory().CreateSubdirectory("out");
+
+        this.fileSystem.AddFile(inputDir.GetFile("ep01.content.yaml"), new MockFileData(SampleContent));
+
+        await this.RunAndAssertAsync(
+            $"markdown export {inputDir.FullName} {outDir.FullName} --ruby Html",
+            expectedOutput: $"Wrote {outDir.GetFile("ep01.md").FullName}");
+
+        var md = this.fileSystem.GetFile(outDir.GetFile("ep01.md")).TextContents;
+        md.Should().Contain("# Opening");
+        md.Should().Contain("<ruby>むかし<rt>むかし</rt></ruby>");
+        md.Should().Contain("Once upon a time.");
+    }
+
+    [Test]
+    public async Task Export_RejectsInvalidRubyOption()
+    {
+        var inputDir = this.fileSystem.GetCurrentDirectory().CreateSubdirectory("in");
+        var outDir = this.fileSystem.GetCurrentDirectory().CreateSubdirectory("out");
+
+        var output = await this.RunAsync(
+            $"markdown export {inputDir.FullName} {outDir.FullName} --ruby bogus");
+
+        output.Result.Should().NotBe(0);
+        output.Error.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/Tandoku.CommandLine.Tests/Tandoku.CommandLine.Tests.csproj
+++ b/tests/Tandoku.CommandLine.Tests/Tandoku.CommandLine.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="21.0.29" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.29" />
     <PackageReference Include="TUnit" Version="1.44.0" />

--- a/tests/Tandoku.CommandLine.Tests/Tandoku.CommandLine.Tests.csproj
+++ b/tests/Tandoku.CommandLine.Tests/Tandoku.CommandLine.Tests.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="21.0.29" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.29" />
     <PackageReference Include="TUnit" Version="1.44.0" />

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_BlurHtmlReferences.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_BlurHtmlReferences.verified.md
@@ -1,0 +1,24 @@
+﻿# Opening
+
+<p class='blurRuby'><input type='checkbox' id='ep01-1'/><label for='ep01-1'><ruby>むかし<rt>むかし</rt></ruby>、ある所にお爺さんとお婆さんが住んでいました。</label></p>
+
+<p><span>en:</span> <span class='blurText'><input type='checkbox' id='ep01-1-ref-en'/><label for='ep01-1-ref-en'>Once upon a time, an old man and old woman lived in a certain place.</label></span></p>
+
+<p><span>time:</span> <span class='blurText'><input type='checkbox' id='ep01-1-ref-time'/><label for='ep01-1-ref-time'>00:00:01</label></span></p>
+
+
+# page-001
+
+![page-001](images/page-001.png)
+
+<p class='blurRuby'><input type='checkbox' id='ep01-2'/><label for='ep01-2'><ruby>桃<rt>もも</rt></ruby><ruby>太郎<rt>たろう</rt></ruby></label></p>
+
+<p><span>en:</span> <span class='blurText'><input type='checkbox' id='ep01-2-ref-en'/><label for='ep01-2-ref-en'>Momotaro</label></span></p>
+
+<p><span>time:</span> <span class='blurText'><input type='checkbox' id='ep01-2-ref-time'/><label for='ep01-2-ref-time'>00:00:05</label></span></p>
+
+
+<audio src="audio/clip01.mp3" controls=""></audio>
+
+<p class='blurRuby'><input type='checkbox' id='ep01-3'/><label for='ep01-3'><ruby>これは音<rt>おと</rt></ruby>のテストです。</label></p>
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_Footnotes.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_Footnotes.verified.md
@@ -1,0 +1,24 @@
+﻿# Opening
+
+<ruby>むかし<rt>むかし</rt></ruby>、ある所にお爺さんとお婆さんが住んでいました。 [^ep01-1]
+
+[^ep01-1]: en: Once upon a time, an old man and old woman lived in a certain place.
+
+    time: 00:00:01
+
+
+# page-001
+
+![page-001](images/page-001.png)
+
+<ruby>桃<rt>もも</rt></ruby><ruby>太郎<rt>たろう</rt></ruby> [^ep01-2]
+
+[^ep01-2]: en: Momotaro
+
+    time: 00:00:05
+
+
+<audio src="audio/clip01.mp3" controls=""></audio>
+
+<ruby>これは音<rt>おと</rt></ruby>のテストです。
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_KeepTogether.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_KeepTogether.verified.md
@@ -1,0 +1,33 @@
+﻿::: {.keep-together}
+# Opening
+
+むかし[むかし]、ある所にお爺さんとお婆さんが住んでいました。
+
+> en: Once upon a time, an old man and old woman lived in a certain place.
+
+> time: 00:00:01
+
+
+:::
+
+::: {.keep-together}
+# page-001
+
+![page-001](images/page-001.png)
+
+桃[もも]太郎[たろう]
+
+> en: Momotaro
+
+> time: 00:00:05
+
+
+:::
+
+::: {.keep-together}
+<audio src="audio/clip01.mp3" controls=""></audio>
+
+これは音[おと]のテストです。
+
+:::
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_KyBook3.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_KyBook3.verified.md
@@ -1,0 +1,18 @@
+﻿# Opening
+
+むかし[むかし]、ある所にお爺さんとお婆さんが住んでいました。 [^ep01-1]
+
+[^ep01-1]: en: Once upon a time, an old man and old woman lived in a certain place.  
+    time: 00:00:01
+
+# page-001
+
+![page-001](images/page-001.png)  
+桃[もも]太郎[たろう] [^ep01-2]
+
+[^ep01-2]: en: Momotaro  
+    time: 00:00:05
+
+<audio src="audio/clip01.mp3" controls="controls"></audio>  
+これは音[おと]のテストです。
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_NoHeadings.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_NoHeadings.verified.md
@@ -1,0 +1,22 @@
+﻿# ep01
+
+むかし、ある所にお爺さんとお婆さんが住んでいました。
+
+> en: Once upon a time, an old man and old woman lived in a certain place.
+
+> time: 00:00:01
+
+
+![page-001](images/page-001.png)
+
+桃太郎
+
+> en: Momotaro
+
+> time: 00:00:05
+
+
+<audio src="audio/clip01.mp3" controls=""></audio>
+
+これは音のテストです。
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_RubyVariants_ruby=Html.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_RubyVariants_ruby=Html.verified.md
@@ -1,0 +1,24 @@
+﻿# Opening
+
+<ruby>むかし<rt>むかし</rt></ruby>、ある所にお爺さんとお婆さんが住んでいました。
+
+> en: Once upon a time, an old man and old woman lived in a certain place.
+
+> time: 00:00:01
+
+
+# page-001
+
+![page-001](images/page-001.png)
+
+<ruby>桃<rt>もも</rt></ruby><ruby>太郎<rt>たろう</rt></ruby>
+
+> en: Momotaro
+
+> time: 00:00:05
+
+
+<audio src="audio/clip01.mp3" controls=""></audio>
+
+<ruby>これは音<rt>おと</rt></ruby>のテストです。
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_RubyVariants_ruby=None.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_RubyVariants_ruby=None.verified.md
@@ -1,0 +1,24 @@
+﻿# Opening
+
+むかし[むかし]、ある所にお爺さんとお婆さんが住んでいました。
+
+> en: Once upon a time, an old man and old woman lived in a certain place.
+
+> time: 00:00:01
+
+
+# page-001
+
+![page-001](images/page-001.png)
+
+桃[もも]太郎[たろう]
+
+> en: Momotaro
+
+> time: 00:00:05
+
+
+<audio src="audio/clip01.mp3" controls=""></audio>
+
+これは音[おと]のテストです。
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_RubyVariants_ruby=Remove.verified.md
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.Export_RubyVariants_ruby=Remove.verified.md
@@ -1,0 +1,24 @@
+﻿# Opening
+
+むかし、ある所にお爺さんとお婆さんが住んでいました。
+
+> en: Once upon a time, an old man and old woman lived in a certain place.
+
+> time: 00:00:01
+
+
+# page-001
+
+![page-001](images/page-001.png)
+
+桃太郎
+
+> en: Momotaro
+
+> time: 00:00:05
+
+
+<audio src="audio/clip01.mp3" controls=""></audio>
+
+これは音のテストです。
+

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.cs
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.cs
@@ -1,0 +1,97 @@
+﻿namespace Tandoku.Tests.Markdown;
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Tandoku.Markdown;
+
+public class MarkdownExporterTests
+{
+    [Test]
+    [Arguments(MarkdownRubyBehavior.None)]
+    [Arguments(MarkdownRubyBehavior.Html)]
+    [Arguments(MarkdownRubyBehavior.Remove)]
+    public Task Export_RubyVariants(MarkdownRubyBehavior ruby) =>
+        this.RunAndVerifyAsync(new MarkdownExportOptions { RubyBehavior = ruby });
+
+    [Test]
+    public Task Export_KeepTogether() =>
+        this.RunAndVerifyAsync(new MarkdownExportOptions { KeepTogether = true });
+
+    [Test]
+    public Task Export_NoHeadings() =>
+        this.RunAndVerifyAsync(new MarkdownExportOptions
+        {
+            NoHeadings = true,
+            RubyBehavior = MarkdownRubyBehavior.Remove,
+        });
+
+    [Test]
+    public Task Export_Footnotes() =>
+        this.RunAndVerifyAsync(new MarkdownExportOptions
+        {
+            RubyBehavior = MarkdownRubyBehavior.Html,
+            ReferenceBehavior = MarkdownReferenceBehavior.Footnotes,
+        });
+
+    [Test]
+    public Task Export_KyBook3() =>
+        this.RunAndVerifyAsync(new MarkdownExportOptions
+        {
+            Quirks = MarkdownQuirks.KyBook3,
+            RubyBehavior = MarkdownRubyBehavior.Html,
+            ReferenceBehavior = MarkdownReferenceBehavior.Footnotes,
+        });
+
+    [Test]
+    public Task Export_BlurHtmlReferences() =>
+        this.RunAndVerifyAsync(new MarkdownExportOptions
+        {
+            RubyBehavior = MarkdownRubyBehavior.BlurHtml,
+            ReferenceBehavior = MarkdownReferenceBehavior.BlurHtml,
+        });
+
+    [Test]
+    public async Task Export_Combined_WritesSingleFile()
+    {
+        var fs = new MockFileSystem();
+        var inputDir = fs.GetCurrentDirectory().CreateSubdirectory("in");
+        WriteSampleResource(fs, inputDir.GetFile("ep01.content.yaml"), "ep01.content.yaml");
+        WriteSampleResource(fs, inputDir.GetFile("ep02.content.yaml"), "ep01.content.yaml");
+
+        var outDir = fs.GetCurrentDirectory().CreateSubdirectory("out");
+        var exporter = new MarkdownExporter(new MarkdownExportOptions
+        {
+            Combine = true,
+            NoHeadings = true,
+        }, fs);
+        var written = await exporter.ExportAsync(inputDir.FullName, outDir.FullName);
+
+        written.Should().HaveCount(1);
+        var combined = fs.File.ReadAllText(written[0]);
+        combined.Should().Contain("# ep01");
+        combined.Should().Contain("# ep02");
+    }
+
+    private async Task RunAndVerifyAsync(MarkdownExportOptions options)
+    {
+        var fs = new MockFileSystem();
+        var inputDir = fs.GetCurrentDirectory().CreateSubdirectory("in");
+        WriteSampleResource(fs, inputDir.GetFile("ep01.content.yaml"), "ep01.content.yaml");
+        var outDir = fs.GetCurrentDirectory().CreateSubdirectory("out");
+
+        var exporter = new MarkdownExporter(options, fs);
+        var written = await exporter.ExportAsync(inputDir.FullName, outDir.FullName);
+
+        written.Should().HaveCount(1);
+        var markdown = fs.File.ReadAllText(written[0]);
+
+        await Verify(markdown, "md");
+    }
+
+    private static void WriteSampleResource(MockFileSystem fs, IFileInfo file, string resourceName)
+    {
+        using var stream = typeof(MarkdownExporterTests).GetManifestResourceStream(resourceName);
+        using var reader = new StreamReader(stream);
+        fs.AddFile(file, new MockFileData(reader.ReadToEnd()));
+    }
+}

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.cs
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.cs
@@ -11,15 +11,15 @@ public class MarkdownExporterTests
     [Arguments(MarkdownRubyBehavior.Html)]
     [Arguments(MarkdownRubyBehavior.Remove)]
     public Task Export_RubyVariants(MarkdownRubyBehavior ruby) =>
-        this.RunAndVerifyAsync(new MarkdownExportOptions { RubyBehavior = ruby });
+        this.RunAndVerifyAsync(new MarkdownExportSettings { RubyBehavior = ruby });
 
     [Test]
     public Task Export_KeepTogether() =>
-        this.RunAndVerifyAsync(new MarkdownExportOptions { KeepTogether = true });
+        this.RunAndVerifyAsync(new MarkdownExportSettings { KeepTogether = true });
 
     [Test]
     public Task Export_NoHeadings() =>
-        this.RunAndVerifyAsync(new MarkdownExportOptions
+        this.RunAndVerifyAsync(new MarkdownExportSettings
         {
             NoHeadings = true,
             RubyBehavior = MarkdownRubyBehavior.Remove,
@@ -27,7 +27,7 @@ public class MarkdownExporterTests
 
     [Test]
     public Task Export_Footnotes() =>
-        this.RunAndVerifyAsync(new MarkdownExportOptions
+        this.RunAndVerifyAsync(new MarkdownExportSettings
         {
             RubyBehavior = MarkdownRubyBehavior.Html,
             ReferenceBehavior = MarkdownReferenceBehavior.Footnotes,
@@ -35,7 +35,7 @@ public class MarkdownExporterTests
 
     [Test]
     public Task Export_KyBook3() =>
-        this.RunAndVerifyAsync(new MarkdownExportOptions
+        this.RunAndVerifyAsync(new MarkdownExportSettings
         {
             Quirks = MarkdownQuirks.KyBook3,
             RubyBehavior = MarkdownRubyBehavior.Html,
@@ -44,7 +44,7 @@ public class MarkdownExporterTests
 
     [Test]
     public Task Export_BlurHtmlReferences() =>
-        this.RunAndVerifyAsync(new MarkdownExportOptions
+        this.RunAndVerifyAsync(new MarkdownExportSettings
         {
             RubyBehavior = MarkdownRubyBehavior.BlurHtml,
             ReferenceBehavior = MarkdownReferenceBehavior.BlurHtml,
@@ -59,7 +59,7 @@ public class MarkdownExporterTests
         WriteSampleResource(fs, inputDir.GetFile("ep02.content.yaml"), "ep01.content.yaml");
 
         var outDir = fs.GetCurrentDirectory().CreateSubdirectory("out");
-        var exporter = new MarkdownExporter(new MarkdownExportOptions
+        var exporter = new MarkdownExporter(new MarkdownExportSettings
         {
             Combine = true,
             NoHeadings = true,
@@ -72,7 +72,7 @@ public class MarkdownExporterTests
         combined.Should().Contain("# ep02");
     }
 
-    private async Task RunAndVerifyAsync(MarkdownExportOptions options)
+    private async Task RunAndVerifyAsync(MarkdownExportSettings options)
     {
         var fs = new MockFileSystem();
         var inputDir = fs.GetCurrentDirectory().CreateSubdirectory("in");

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.cs
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExporterTests.cs
@@ -72,14 +72,14 @@ public class MarkdownExporterTests
         combined.Should().Contain("# ep02");
     }
 
-    private async Task RunAndVerifyAsync(MarkdownExportSettings options)
+    private async Task RunAndVerifyAsync(MarkdownExportSettings settings)
     {
         var fs = new MockFileSystem();
         var inputDir = fs.GetCurrentDirectory().CreateSubdirectory("in");
         WriteSampleResource(fs, inputDir.GetFile("ep01.content.yaml"), "ep01.content.yaml");
         var outDir = fs.GetCurrentDirectory().CreateSubdirectory("out");
 
-        var exporter = new MarkdownExporter(options, fs);
+        var exporter = new MarkdownExporter(settings, fs);
         var written = await exporter.ExportAsync(inputDir.FullName, outDir.FullName);
 
         written.Should().HaveCount(1);

--- a/tests/Tandoku.Core.Tests/Markdown/MarkdownExtensionsTests.cs
+++ b/tests/Tandoku.Core.Tests/Markdown/MarkdownExtensionsTests.cs
@@ -7,7 +7,7 @@ public class MarkdownExtensionsTests
     [Test]
     public void ToPlainText_StripsMarkdown()
     {
-        new Md("**bold** and *em*").ToPlainText().Should().Be($"bold and em{Environment.NewLine}");
+        new Md("**bold** and *em*").ToPlainText().Should().Be($"bold and em\n");
     }
 
     [Test]

--- a/tests/Tandoku.Core.Tests/Markdown/ep01.content.yaml
+++ b/tests/Tandoku.Core.Tests/Markdown/ep01.content.yaml
@@ -1,0 +1,33 @@
+source:
+  note: Opening
+  timecodes:
+    start: 00:00:01.5
+    end: 00:00:03.0
+chunks:
+- text: |-
+    むかし[むかし]、ある所にお爺さんとお婆さんが住んでいました。
+  references:
+    en:
+      text: Once upon a time, an old man and old woman lived in a certain place.
+---
+source:
+  timecodes:
+    start: 00:00:05.0
+    end: 00:00:07.0
+image:
+  name: page-001.png
+chunks:
+- text: 桃[もも]太郎[たろう]
+  references:
+    en:
+      text: Momotaro
+---
+source:
+  timecodes:
+    start: 00:00:09.0
+    end: 00:00:11.0
+audio:
+  name: clip01.mp3
+chunks:
+- text: |-
+    これは音[おと]のテストです。

--- a/tests/Tandoku.Core.Tests/Tandoku.Core.Tests.csproj
+++ b/tests/Tandoku.Core.Tests/Tandoku.Core.Tests.csproj
@@ -8,6 +8,9 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Markdown\*.yaml" Exclude="Markdown\*.verified.*">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
     <EmbeddedResource Include="Subtitles\*.ttml" Exclude="Subtitles\*.verified.*">
       <WithCulture>false</WithCulture>
     </EmbeddedResource>

--- a/tests/Tandoku.Core.Tests/Tandoku.Core.Tests.csproj
+++ b/tests/Tandoku.Core.Tests/Tandoku.Core.Tests.csproj
@@ -20,10 +20,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="21.0.29" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.29" />
     <PackageReference Include="TUnit" Version="1.44.0" />

--- a/tests/Tandoku.Core.Tests/Tandoku.Core.Tests.csproj
+++ b/tests/Tandoku.Core.Tests/Tandoku.Core.Tests.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="21.0.29" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.29" />
     <PackageReference Include="TUnit" Version="1.44.0" />


### PR DESCRIPTION
Add MarkdownExporter in Tandoku.Core/Markdown using Scriban templates for block-level structure with C# helpers for ruby substitution, blur HTML rendering, footnote/blockquote references, and KyBook 3 quirks.

Wire up 'tandoku markdown export' CLI command with options matching the original TandokuMarkdownExport.ps1 script.

Output is byte-identical to the PowerShell script across all option combinations (defaults, KeepTogether, Footnotes, KyBook3, NoHeadings).

Tests cover ruby variants, reference behaviors, and quirks via Verify snapshots over an embedded sample content file.