### PR TITLE
Prefetch full Natively catalog instead of per-title search

### DIFF
--- a/scripts/discover/films/PopulateNatively.ps1
+++ b/scripts/discover/films/PopulateNatively.ps1
@@ -1,7 +1,14 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [string]$DatabasePath
+    [string]$DatabasePath,
+
+    [Parameter(Mandatory)]
+    [string]$NativelyDataPath,
+
+    [switch]$UpdateNativelyData,
+
+    [string]$Language = 'jpn'
 )
 
 Import-Module "$PSScriptRoot\..\..\modules\tandoku-yaml.psm1"
@@ -35,62 +42,129 @@ function Reorder-FilmEntry($film) {
     return $ordered
 }
 
-function Search-Natively($query) {
-    $encoded = [uri]::EscapeDataString($query)
-    $url = "$nativelyBaseUrl/api/ninja/search/videos/?language=jpn&q=$encoded&series=series"
-    return Invoke-RestMethod -Uri $url -Headers $nativelyHeaders
-}
-
 function Format-NativelyLevel($rating) {
     if (-not $rating -or $null -eq $rating.lvl) { return $null }
     return [int]$rating.lvl
 }
 
-# Produce a relaxed version of a title for a fallback search: strips parenthetical
-# annotations (half- or full-width) and any subtitle following a colon, e.g.
-# 'HUNTER×HUNTER (2011年のアニメ)' -> 'HUNTER×HUNTER' and '愛なき森で叫べ : Deep Cut' -> '愛なき森で叫べ'.
-function Get-RelaxedQuery($query) {
-    $relaxed = $query -replace '[\(（][^\)）]*[\)）]', ''
-    $relaxed = ($relaxed -split '[:：]', 2)[0]
-    # Drop zero-width/BOM characters and surrounding whitespace
-    $relaxed = ($relaxed -replace '[\uFEFF\u200B]', '').Trim()
-    return $relaxed
-}
-
-# Search Natively results for an entry whose TMDB ID matches $tmdbId; returns a
-# match descriptor (level/temporary/url) or $null if none of the results match.
-function Find-NativelyMatch($results, $tmdbId) {
-    foreach ($result in $results) {
-        if ($result.widget -eq 'series') {
-            if ([int]$result.series.tmdb_id -eq [int]$tmdbId) {
-                return @{
-                    level     = Format-NativelyLevel $result.series.rating
-                    temporary = [bool]$result.series.rating.temporary
-                    url       = "$nativelyBaseUrl$($result.series.url)"
-                }
-            }
-        } else {
-            # 'item' widget - check both item-level and series-level tmdb_id
-            if ([int]$result.item.tmdb_id -eq [int]$tmdbId) {
-                return @{
-                    level     = Format-NativelyLevel $result.item.rating
-                    temporary = [bool]$result.item.rating.temporary
-                    url       = "$nativelyBaseUrl$($result.item.url)"
-                }
-            }
-            if ($result.item.series -and [int]$result.item.series.tmdb_id -eq [int]$tmdbId) {
-                return @{
-                    level     = Format-NativelyLevel $result.item.rating
-                    temporary = [bool]$result.item.rating.temporary
-                    url       = "$nativelyBaseUrl$($result.item.series.url)"
-                }
-            }
+# Normalize a single Natively search result into a record keyed by TMDB id + kind.
+# Movies map to a 'movie' record; TV series (and TV seasons, via their parent
+# series) map to a 'tv-series' record so they can be matched against the films
+# database, where tmdb.kind is either 'movie' or 'tv-series'.
+function ConvertTo-NativelyRecord($result) {
+    if ($result.widget -eq 'series') {
+        $series = $result.series
+        if ($null -eq $series.tmdb_id) { return $null }
+        return [ordered]@{
+            tmdbId    = [int]$series.tmdb_id
+            tmdbKind  = 'tv-series'
+            title     = $series.title
+            url       = "$nativelyBaseUrl$($series.url)"
+            level     = Format-NativelyLevel $series.rating
+            temporary = [bool]$series.rating.temporary
+            source    = 'series'
         }
     }
+
+    $item = $result.item
+    if ($item.media_type -eq 'movie') {
+        if ($null -eq $item.tmdb_id) { return $null }
+        return [ordered]@{
+            tmdbId    = [int]$item.tmdb_id
+            tmdbKind  = 'movie'
+            title     = $item.title
+            url       = "$nativelyBaseUrl$($item.url)"
+            level     = Format-NativelyLevel $item.rating
+            temporary = [bool]$item.rating.temporary
+            source    = 'movie'
+        }
+    }
+
+    # Other item kinds (e.g. tv_season) belong to a parent series; key them by
+    # the parent series' TMDB id so a 'tv-series' entry can still match when no
+    # standalone series widget is present.
+    if ($item.series -and $null -ne $item.series.tmdb_id) {
+        return [ordered]@{
+            tmdbId    = [int]$item.series.tmdb_id
+            tmdbKind  = 'tv-series'
+            title     = $item.series.title
+            url       = "$nativelyBaseUrl$($item.series.url)"
+            level     = Format-NativelyLevel $item.rating
+            temporary = [bool]$item.rating.temporary
+            source    = 'season'
+        }
+    }
+
     return $null
 }
 
-# Read films database
+# Fetch every available video for $language from Natively, paging until all
+# pages have been retrieved.
+function Get-NativelyVideos($language) {
+    $videos = [System.Collections.Generic.List[object]]::new()
+    $page = 1
+    $numPages = $null
+    $totalCount = 0
+
+    while ($true) {
+        $url = "$nativelyBaseUrl/api/ninja/search/videos/?language=$language&series=series&p=$page"
+        $resp = Invoke-RestMethod -Uri $url -Headers $nativelyHeaders
+
+        if ($null -eq $numPages) {
+            $numPages = [int]$resp.num_of_pages
+            $totalCount = [int]$resp.total_count
+            Write-Host "Fetching $totalCount Natively videos across $numPages page(s)..."
+        }
+
+        foreach ($result in @($resp.results)) {
+            $record = ConvertTo-NativelyRecord $result
+            if ($record) {
+                $videos.Add($record)
+            }
+        }
+
+        Write-Host "  page $page/$numPages ($($videos.Count) records so far)"
+
+        if ($page -ge $numPages) { break }
+        $page++
+
+        # Throttle requests to avoid overwhelming the site
+        Start-Sleep -Milliseconds (1000 + (Get-Random -Maximum 1000))
+    }
+
+    return [ordered]@{
+        language   = $language
+        fetchedAt  = (Get-Date).ToString('o')
+        totalCount = $totalCount
+        videos     = $videos
+    }
+}
+
+# Build a lookup table keyed by "<tmdbKind>|<tmdbId>". When the same key appears
+# more than once, prefer a record that has a usable level, then prefer series
+# widgets and movies over season-derived records.
+function Get-NativelyRecordPriority($video) {
+    $hasLevel = if ($null -ne $video.level) { 2 } else { 0 }
+    $sourceRank = if ($video.source -eq 'season') { 0 } else { 1 }
+    return $hasLevel + $sourceRank
+}
+
+function Build-NativelyIndex($videos) {
+    $index = @{}
+    foreach ($video in $videos) {
+        if ($null -eq $video.tmdbId) { continue }
+        $key = "$($video.tmdbKind)|$([int]$video.tmdbId)"
+        $priority = Get-NativelyRecordPriority $video
+        $existing = $index[$key]
+        if ($null -eq $existing -or $priority -gt $existing.priority) {
+            $index[$key] = [pscustomobject]@{ video = $video; priority = $priority }
+        }
+    }
+    return $index
+}
+
+# --- Read films database ---
+
 $films = [System.Collections.Generic.List[object]]::new()
 foreach ($doc in @(Import-Yaml -LiteralPath $DatabasePath)) {
     $films.Add($doc)
@@ -116,10 +190,38 @@ foreach ($film in $films) {
     }
 }
 
+# Skip fetching the (large) Natively dataset entirely when there is nothing to
+# match and the caller has not explicitly asked to refresh the local data.
+if ($needsNatively.Count -eq 0 -and -not $UpdateNativelyData) {
+    Write-Host "No entries need Natively lookup"
+    return
+}
+
+# --- Download Natively data if needed ---
+
+if (-not (Test-Path $NativelyDataPath)) {
+    New-Item -ItemType Directory -Path $NativelyDataPath | Out-Null
+}
+
+$NativelyDataPath = Resolve-Path $NativelyDataPath
+$videosJsonPath = Join-Path $NativelyDataPath "natively-videos-$Language.json"
+
+if ($UpdateNativelyData -or -not (Test-Path $videosJsonPath)) {
+    $data = Get-NativelyVideos $Language
+    $data | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $videosJsonPath -Encoding UTF8
+    Write-Host "Saved $($data.videos.Count) Natively video records to $videosJsonPath"
+}
+else {
+    $data = Get-Content -LiteralPath $videosJsonPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    Write-Host "Loaded $($data.videos.Count) Natively video records from $videosJsonPath"
+}
+
 if ($needsNatively.Count -eq 0) {
     Write-Host "No entries need Natively lookup"
     return
 }
+
+$index = Build-NativelyIndex $data.videos
 
 Write-Host "$($needsNatively.Count) entries need Natively lookup"
 
@@ -128,63 +230,28 @@ $notFound = 0
 
 foreach ($film in $needsNatively) {
     $titleJa = $film.'title-ja'
-    $tmdbId = $film.tmdb.id
+    $tmdbId = [int]$film.tmdb.id
+    $tmdbKind = $film.tmdb.kind
 
-    # Throttle requests
-    $delay = 1000 + (Get-Random -Maximum 1000)
-    Start-Sleep -Milliseconds $delay
+    $key = "$tmdbKind|$tmdbId"
+    $entry = $index[$key]
+    $matchedResult = if ($entry) { $entry.video } else { $null }
 
-    try {
-        $searchResult = Search-Natively $titleJa
-    }
-    catch {
-        Write-Warning "Failed to search Natively for '$titleJa': $_"
-        continue
-    }
-
-    $results = @($searchResult.results)
-    $resultCount = $results.Count
-
-    # Search through results for a TMDB ID match
-    $matchedResult = Find-NativelyMatch $results $tmdbId
-
-    # Fall back to a relaxed query (parenthetical/subtitle stripped) if no match
-    if (-not ($matchedResult -and $matchedResult.level)) {
-        $relaxedQuery = Get-RelaxedQuery $titleJa
-        if ($relaxedQuery -and $relaxedQuery -ne $titleJa) {
-            $delay = 1000 + (Get-Random -Maximum 1000)
-            Start-Sleep -Milliseconds $delay
-            try {
-                $relaxedSearch = Search-Natively $relaxedQuery
-                $relaxedResults = @($relaxedSearch.results)
-                $relaxedMatch = Find-NativelyMatch $relaxedResults $tmdbId
-                if ($relaxedMatch -and $relaxedMatch.level) {
-                    $matchedResult = $relaxedMatch
-                    $resultCount = $relaxedResults.Count
-                    Write-Host "Relaxed match for '$titleJa' using '$relaxedQuery'"
-                }
-            }
-            catch {
-                Write-Warning "Failed relaxed Natively search for '$relaxedQuery': $_"
-            }
-        }
-    }
-
-    if ($matchedResult -and $matchedResult.level) {
+    if ($matchedResult -and $null -ne $matchedResult.level) {
         $film['natively'] = [ordered]@{
-            level = $matchedResult.level
+            level = [int]$matchedResult.level
             url   = $matchedResult.url
         }
         if ($matchedResult.temporary) {
             $film['natively']['temporaryLevel'] = $true
         }
         # Capture the TMDB info that was matched so we can recheck Natively if it changes
-        $film['natively']['tmdbId'] = [int]$film.tmdb.id
-        $film['natively']['tmdbKind'] = $film.tmdb.kind
+        $film['natively']['tmdbId'] = $tmdbId
+        $film['natively']['tmdbKind'] = $tmdbKind
         $matched++
         Write-Host "Matched '$titleJa' -> $($matchedResult.url) (level $($matchedResult.level))"
     } else {
-        Write-Warning "No Natively match for '$titleJa' (tmdb=$tmdbId kind=$($film.tmdb.kind) wikidata=$($film.wikidata)) - $resultCount search result(s)"
+        Write-Warning "No Natively match for '$titleJa' (tmdb=$tmdbId kind=$tmdbKind wikidata=$($film.wikidata))"
         $notFound++
     }
 }

--- a/scripts/discover/films/discover-films-spec.md
+++ b/scripts/discover/films/discover-films-spec.md
@@ -107,14 +107,19 @@ Downloads `title.ratings.tsv.gz` from IMDb daily data dumps and extracts it to t
 ## PopulateNatively.ps1
 ### Usage
 ```powershell
-PopulateNatively.ps1 -DatabasePath <films.yaml>
+PopulateNatively.ps1 -DatabasePath <films.yaml> -NativelyDataPath <path> [-UpdateNativelyData] [-Language <code>]
 ```
 
 ### Parameters
 - `-DatabasePath` - Path to the films.yaml database file.
+- `-NativelyDataPath` - Path to a local folder for storing the Natively video catalog downloaded from [Natively](https://learnnatively.com).
+- `-UpdateNativelyData` - When specified, re-downloads the Natively catalog even if a local copy already exists.
+- `-Language` - Natively language code for the catalog (defaults to `jpn`). Determines the API language and the local file name `natively-videos-<lang>.json`.
 
 ### Behavior
-For each entry in films.yaml with `originalLanguage` of `ja` that has `title-ja` and `tmdb.id`, searches [Natively](https://learnnatively.com) for the Japanese title and matches results by TMDB ID. An entry is searched when it is missing `natively`, or when the captured `natively.tmdbId`/`natively.tmdbKind` are missing or no longer match the entry's current `tmdb.id`/`tmdb.kind` (so the Natively match is rechecked whenever the TMDB info changes). If the initial search yields no TMDB match, retries once with a relaxed query that strips parenthetical annotations and any subtitle following a colon (e.g. `HUNTER×HUNTER (2011年のアニメ)` → `HUNTER×HUNTER`, `愛なき森で叫べ : Deep Cut` → `愛なき森で叫べ`). If a match is found, populates `natively.level` (difficulty level), `natively.url`, `natively.temporaryLevel` (set to `true` when the level is a temporary rating), and records `natively.tmdbId` and `natively.tmdbKind` (the TMDB info that was matched). Warns if no matching result is found. Sleeps 1-2 seconds between requests to avoid overwhelming the site.
+Pre-fetches the entire Natively video catalog for the language (paging through the search API with no `q=` filter) and stores it as `natively-videos-<lang>.json` in `-NativelyDataPath`. Uses the existing local file unless it is missing or `-UpdateNativelyData` is specified. Each catalog entry is normalized to a TMDB id, a kind (`movie` or `tv-series`, distinguishing movies from TV series/seasons), difficulty level, and URL.
+
+For each entry in films.yaml with `originalLanguage` of `ja` that has `title-ja` and `tmdb.id`, matches against the local catalog by `tmdb.id` and `tmdb.kind` directly. An entry is matched when it is missing `natively`, or when the captured `natively.tmdbId`/`natively.tmdbKind` are missing or no longer match the entry's current `tmdb.id`/`tmdb.kind` (so the Natively match is rechecked whenever the TMDB info changes). If a match is found, populates `natively.level` (difficulty level), `natively.url`, `natively.temporaryLevel` (set to `true` when the level is a temporary rating), and records `natively.tmdbId` and `natively.tmdbKind` (the TMDB info that was matched). Warns if no matching catalog entry is found. The catalog download is skipped entirely when no entries need a lookup and `-UpdateNativelyData` is not specified.
 
 ## ExportFilms.ps1
 ### Usage


### PR DESCRIPTION
## Why

`PopulateNatively.ps1` previously hit the LearnNatively search API once per film, using the `q=` title query and then matching results by TMDb ID. That is slow, fragile (titles often don't match cleanly, requiring a relaxed-query fallback), and hammers the site with one request per entry.

## What changed

The search API returns the entire video catalog with paging when `q=` is omitted, so the script now pre-fetches that catalog once and matches locally:

- **Prefetch + cache.** Pages through the API (paging param is `p`, ~96 pages / 5,700+ videos) and stores a normalized catalog as `natively-videos-<lang>.json`.
- **New parameters**, following the `PopulateIMDb.ps1` pattern: `-NativelyDataPath` (cache directory) and `-UpdateNativelyData` (refetch even when a local copy exists), plus `-Language` (default `jpn`) which drives the cache file name. The catalog is refetched only when the flag is set or the file is missing.
- **Movie vs TV disambiguation.** Each catalog entry is normalized to `{tmdbId, tmdbKind, level, url, temporary, source}`, where `series` widgets and `tv_season` parent series map to `tv-series` and movie items map to `movie`. Matching is keyed by `tmdbKind|tmdbId`, so the separate movie and TV TMDb ID spaces never collide.
- **Direct matching.** Titles now match the cached catalog by TMDb id + kind directly, removing the old per-title query and relaxed-query fallback.

## Notes for reviewers

- When several catalog records share a TMDb series id (a series widget plus its season items), the index prefers a record with a usable difficulty level, then prefers series/movie records over season-derived ones.
- Films are read and filtered before any download, so the large catalog fetch is skipped entirely (and stays offline-safe) when nothing needs a lookup and `-UpdateNativelyData` was not passed.
- The `natively.*` fields written to films.yaml (`level`, `url`, `temporaryLevel`, `tmdbId`, `tmdbKind`) are unchanged, so downstream consumers are unaffected.

Verified end to end against live data: a full fetch wrote 5,738 records, movie and TV-series entries matched (including `temporaryLevel`), unmatched entries warned, and the skip-fetch path created no directory. `discover-films-spec.md` is updated to match.