### PR TITLE
Add Wikidata identifier suggestion and commit pipeline for films

### DIFF
--- a/scripts/discover/films/CommitWikidataIdentifiers.ps1
+++ b/scripts/discover/films/CommitWikidataIdentifiers.ps1
@@ -1,0 +1,217 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [string]$CandidatesPath,
+
+    [Parameter()]
+    [string]$AccessToken,
+
+    [Parameter()]
+    [string]$ApiUrl = 'https://www.wikidata.org/w/api.php'
+)
+
+Import-Module "$PSScriptRoot/../../modules/tandoku-yaml.psm1"
+
+# Wikidata properties for the external identifiers we commit
+$netflixProperty = 'P1874'
+$imdbProperty = 'P345'
+
+$userAgent = 'tandoku-discover/1.0 (https://github.com/tandoku)'
+
+# OAuth 2.0 owner-only access token - parameter takes precedence, otherwise environment variable.
+# Reading existing claims is public, so a token is only required when actually writing.
+$token = if ($AccessToken) { $AccessToken } else { $env:WIKIDATA_ACCESS_TOKEN }
+if (-not $WhatIfPreference -and -not $token) {
+    throw "Wikidata access token required. Pass -AccessToken or set WIKIDATA_ACCESS_TOKEN (or use -WhatIf to preview)."
+}
+
+$authHeaders = @{ 'User-Agent' = $userAgent }
+if ($token) {
+    $authHeaders['Authorization'] = "Bearer $token"
+}
+
+$script:csrfToken = $null
+function Get-CsrfToken {
+    if (-not $script:csrfToken) {
+        $body = @{ action = 'query'; meta = 'tokens'; type = 'csrf'; format = 'json' }
+        $resp = Invoke-RestMethod -Uri $ApiUrl -Method Post -Body $body -Headers $authHeaders
+        $script:csrfToken = $resp.query.tokens.csrftoken
+        if (-not $script:csrfToken -or $script:csrfToken -eq '+\') {
+            throw "Failed to obtain a CSRF token (the access token may be invalid or lack edit rights)."
+        }
+    }
+    return $script:csrfToken
+}
+
+# Returns the existing values of a string/external-id property on an entity (empty list if none).
+function Get-ClaimValues([string]$qid, [string]$property) {
+    $uri = "$ApiUrl`?action=wbgetclaims&entity=$qid&property=$property&format=json"
+    $resp = Invoke-RestMethod -Uri $uri -Headers $authHeaders
+    if ($resp.error) {
+        throw "wbgetclaims failed for $qid/$property`: $($resp.error.code) - $($resp.error.info)"
+    }
+    $values = [System.Collections.Generic.List[string]]::new()
+    if ($resp.claims) {
+        foreach ($claim in @($resp.claims.$property)) {
+            if ($null -eq $claim) { continue }
+            $v = $claim.mainsnak.datavalue.value
+            if ($null -ne $v) { $values.Add([string]$v) }
+        }
+    }
+    return $values
+}
+
+# Adds a string/external-id claim, retrying on Wikidata replication lag.
+function Add-StringClaim([string]$qid, [string]$property, [string]$value) {
+    $body = @{
+        action   = 'wbcreateclaim'
+        entity   = $qid
+        snaktype = 'value'
+        property = $property
+        value    = (ConvertTo-Json $value -Compress)
+        token    = (Get-CsrfToken)
+        assert   = 'user'
+        maxlag   = 5
+        summary  = "tandoku: add $property identifier"
+        format   = 'json'
+    }
+
+    $maxRetries = 3
+    for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
+        $resp = Invoke-RestMethod -Uri $ApiUrl -Method Post -Body $body -Headers $authHeaders
+        if ($resp.success -eq 1) {
+            return $true
+        }
+        if ($resp.error -and $resp.error.code -eq 'maxlag' -and $attempt -lt $maxRetries) {
+            Write-Warning "Wikidata lagged; waiting 5s before retry $attempt/$maxRetries..."
+            Start-Sleep -Seconds 5
+            continue
+        }
+        $err = if ($resp.error) { "$($resp.error.code) - $($resp.error.info)" } else { 'unknown error' }
+        Write-Warning "Failed to add $property=$value to $qid`: $err"
+        return $false
+    }
+    return $false
+}
+
+# --- Read candidates ---
+
+$candidates = @(Import-Yaml $CandidatesPath)
+Write-Host "Read $($candidates.Count) candidate records from $CandidatesPath"
+
+$verifiedCount = 0
+$skipped = 0
+$upToDate = 0
+$claimsAdded = 0
+
+foreach ($record in $candidates) {
+    if ($record.verified -ne $true) {
+        continue
+    }
+    $verifiedCount++
+
+    $qid = if ($record.wikidata) { [string]$record.wikidata.id } else { $null }
+    $netflixLabel = if ($record.netflix) { $record.netflix.id } else { '(no netflix id)' }
+
+    if (-not $qid) {
+        Write-Warning "Netflix $netflixLabel is verified but has no wikidata.id; skipping"
+        $skipped++
+        continue
+    }
+    if ($qid -notmatch '^Q[1-9][0-9]*$') {
+        Write-Warning "Netflix $netflixLabel has invalid wikidata.id '$qid'; skipping"
+        $skipped++
+        continue
+    }
+
+    # Netflix ID (optional)
+    $netflixId = $null
+    if ($record.netflix -and $null -ne $record.netflix.id) {
+        $netflixId = [string]$record.netflix.id
+        if ($netflixId -notmatch '^[0-9]+$') {
+            Write-Warning "$qid has invalid netflix.id '$netflixId'; skipping"
+            $skipped++
+            continue
+        }
+    }
+
+    # IMDb candidates - a single entry is required to commit an IMDb ID.
+    # Assign directly (not via an if-expression) so a single-element array is not unwrapped.
+    [object[]]$imdbEntries = @()
+    if ($null -ne $record.imdb) {
+        $imdbEntries = @($record.imdb)
+    }
+    if ($imdbEntries.Count -gt 1) {
+        Write-Warning "$qid (Netflix $netflixLabel) has $($imdbEntries.Count) IMDb candidates; remove the incorrect entries first. Skipping."
+        $skipped++
+        continue
+    }
+    $imdbId = $null
+    if ($imdbEntries.Count -eq 1) {
+        $imdbId = [string]$imdbEntries[0].id
+        if ($imdbId -notmatch '^tt[0-9]+$') {
+            Write-Warning "$qid has invalid imdb.id '$imdbId'; skipping"
+            $skipped++
+            continue
+        }
+    }
+
+    if (-not $netflixId -and -not $imdbId) {
+        Write-Warning "$qid has neither netflix.id nor imdb.id; skipping"
+        $skipped++
+        continue
+    }
+
+    try {
+        $existingImdb = @(Get-ClaimValues $qid $imdbProperty)
+        $existingNetflix = @(Get-ClaimValues $qid $netflixProperty)
+    }
+    catch {
+        Write-Warning "Failed to read existing claims for $qid`: $_. Skipping."
+        $skipped++
+        continue
+    }
+
+    # A pre-existing, non-matching external ID means this wikidata.id mapping is suspect;
+    # make no change to the record at all.
+    if ($imdbId -and $existingImdb.Count -gt 0 -and $existingImdb -notcontains $imdbId) {
+        Write-Warning "$qid already has IMDb ID(s) [$($existingImdb -join ', ')] that do not match candidate '$imdbId'; skipping"
+        $skipped++
+        continue
+    }
+    if ($netflixId -and $existingNetflix.Count -gt 0 -and $existingNetflix -notcontains $netflixId) {
+        Write-Warning "$qid already has Netflix ID(s) [$($existingNetflix -join ', ')] that do not match candidate '$netflixId'; skipping"
+        $skipped++
+        continue
+    }
+
+    # Determine which claims are missing (idempotent - never duplicate an existing value)
+    $toAdd = [System.Collections.Generic.List[object]]::new()
+    if ($netflixId -and $existingNetflix -notcontains $netflixId) {
+        $toAdd.Add(@{ property = $netflixProperty; value = $netflixId })
+    }
+    if ($imdbId -and $existingImdb -notcontains $imdbId) {
+        $toAdd.Add(@{ property = $imdbProperty; value = $imdbId })
+    }
+
+    if ($toAdd.Count -eq 0) {
+        Write-Host "$qid already up to date"
+        $upToDate++
+        continue
+    }
+
+    if (-not $imdbId) {
+        Write-Host "$qid has no IMDb candidate; committing Netflix ID only"
+    }
+
+    foreach ($claim in $toAdd) {
+        if ($PSCmdlet.ShouldProcess($qid, "add $($claim.property) = $($claim.value)")) {
+            if (Add-StringClaim $qid $claim.property $claim.value) {
+                Write-Host "$qid`: added $($claim.property) = $($claim.value)"
+                $claimsAdded++
+            }
+        }
+    }
+}
+
+Write-Host "Done - $verifiedCount verified record(s): added $claimsAdded claim(s), $upToDate already up to date, $skipped skipped"

--- a/scripts/discover/films/CommitWikidataIdentifiers.ps1
+++ b/scripts/discover/films/CommitWikidataIdentifiers.ps1
@@ -25,16 +25,19 @@ if (-not $WhatIfPreference -and -not $token) {
     throw "Wikidata access token required. Pass -AccessToken or set WIKIDATA_ACCESS_TOKEN (or use -WhatIf to preview)."
 }
 
-$authHeaders = @{ 'User-Agent' = $userAgent }
+# Reads (wbgetclaims) are public, so they must never send the access token -
+# an invalid/mismatched token would otherwise break reads (and -WhatIf).
+$readHeaders = @{ 'User-Agent' = $userAgent }
+$writeHeaders = @{ 'User-Agent' = $userAgent }
 if ($token) {
-    $authHeaders['Authorization'] = "Bearer $token"
+    $writeHeaders['Authorization'] = "Bearer $token"
 }
 
 $script:csrfToken = $null
 function Get-CsrfToken {
     if (-not $script:csrfToken) {
         $body = @{ action = 'query'; meta = 'tokens'; type = 'csrf'; format = 'json' }
-        $resp = Invoke-RestMethod -Uri $ApiUrl -Method Post -Body $body -Headers $authHeaders
+        $resp = Invoke-RestMethod -Uri $ApiUrl -Method Post -Body $body -Headers $writeHeaders
         $script:csrfToken = $resp.query.tokens.csrftoken
         if (-not $script:csrfToken -or $script:csrfToken -eq '+\') {
             throw "Failed to obtain a CSRF token (the access token may be invalid or lack edit rights)."
@@ -46,7 +49,7 @@ function Get-CsrfToken {
 # Returns the existing values of a string/external-id property on an entity (empty list if none).
 function Get-ClaimValues([string]$qid, [string]$property) {
     $uri = "$ApiUrl`?action=wbgetclaims&entity=$qid&property=$property&format=json"
-    $resp = Invoke-RestMethod -Uri $uri -Headers $authHeaders
+    $resp = Invoke-RestMethod -Uri $uri -Headers $readHeaders
     if ($resp.error) {
         throw "wbgetclaims failed for $qid/$property`: $($resp.error.code) - $($resp.error.info)"
     }
@@ -78,7 +81,7 @@ function Add-StringClaim([string]$qid, [string]$property, [string]$value) {
 
     $maxRetries = 3
     for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
-        $resp = Invoke-RestMethod -Uri $ApiUrl -Method Post -Body $body -Headers $authHeaders
+        $resp = Invoke-RestMethod -Uri $ApiUrl -Method Post -Body $body -Headers $writeHeaders
         if ($resp.success -eq 1) {
             return $true
         }

--- a/scripts/discover/films/PopulateIMDb.ps1
+++ b/scripts/discover/films/PopulateIMDb.ps1
@@ -31,28 +31,8 @@ function Reorder-FilmEntry($film) {
 
 # --- Download IMDb data if needed ---
 
-if (-not (Test-Path $ImdbDataPath)) {
-    New-Item -ItemType Directory -Path $ImdbDataPath | Out-Null
-}
-
-$ImdbDataPath = Resolve-Path $ImdbDataPath
-$ratingsGzPath = Join-Path $ImdbDataPath 'title.ratings.tsv.gz'
-$ratingsTsvPath = Join-Path $ImdbDataPath 'title.ratings.tsv'
-
-if ($UpdateImdbData -or -not (Test-Path $ratingsTsvPath)) {
-    $ratingsUrl = 'https://datasets.imdbws.com/title.ratings.tsv.gz'
-    Write-Host "Downloading $ratingsUrl..."
-    Invoke-WebRequest -Uri $ratingsUrl -OutFile $ratingsGzPath
-
-    Write-Host "Extracting title.ratings.tsv..."
-    $gzIn = [System.IO.File]::OpenRead($ratingsGzPath)
-    $gzStream = [System.IO.Compression.GZipStream]::new($gzIn, [System.IO.Compression.CompressionMode]::Decompress)
-    $tsvOut = [System.IO.File]::Create($ratingsTsvPath)
-    $gzStream.CopyTo($tsvOut)
-    $tsvOut.Close()
-    $gzStream.Close()
-    $gzIn.Close()
-}
+$imdbData = & "$PSScriptRoot/UpdateIMDbData.ps1" -ImdbDataPath $ImdbDataPath -Datasets 'title.ratings' -UpdateImdbData:$UpdateImdbData
+$ratingsTsvPath = $imdbData['title.ratings']
 
 # --- Load IMDb ratings into lookup table ---
 

--- a/scripts/discover/films/SuggestWikidataIdentifiers.ps1
+++ b/scripts/discover/films/SuggestWikidataIdentifiers.ps1
@@ -143,7 +143,9 @@ $imdbData = & "$PSScriptRoot/UpdateIMDbData.ps1" `
 
 # Candidate IMDb titles keyed by tconst.
 #   films          = set of Netflix films this tconst was title-matched to
+#   title          = IMDb primary title (from basics)
 #   titleType      = IMDb title type (from basics)
+#   year           = IMDb start year (from basics, $null when unknown)
 #   japaneseAka    = has an alternate title in Japanese (language 'ja' or CJK text)
 #   japaneseOrig   = basics originalTitle contains Japanese text
 #   votes          = IMDb vote count (tie-breaker)
@@ -153,7 +155,9 @@ function Add-Candidate([string]$tconst, $matchedFilms) {
     if (-not $candidates.ContainsKey($tconst)) {
         $candidates[$tconst] = [ordered]@{
             films        = [System.Collections.Generic.Dictionary[object, object]]::new()
+            title        = $null
             titleType    = $null
+            year         = $null
             japaneseAka  = $false
             japaneseOrig = $false
             votes        = 0
@@ -234,8 +238,8 @@ $lineCount = 0
 foreach ($line in [System.IO.File]::ReadLines($basicsPath)) {
     $lineCount++
     if ($lineCount -eq 1) { continue } # header
-    # tconst, titleType, primaryTitle, originalTitle, ...
-    $fields = $line.Split("`t", 5)
+    # tconst, titleType, primaryTitle, originalTitle, isAdult, startYear, ...
+    $fields = $line.Split("`t", 7)
     if ($fields.Count -lt 4) { continue }
     $tconst = $fields[0]
     $primaryTitle = $fields[2]
@@ -249,7 +253,12 @@ foreach ($line in [System.IO.File]::ReadLines($basicsPath)) {
     }
 
     if ($candidates.ContainsKey($tconst)) {
+        $candidates[$tconst].title = $primaryTitle
         $candidates[$tconst].titleType = $fields[1]
+        $startYear = if ($fields.Count -ge 6) { $fields[5] } else { '\N' }
+        if ($startYear -and $startYear -ne '\N') {
+            $candidates[$tconst].year = [int]$startYear
+        }
         $candidates[$tconst].japaneseOrig = Test-ContainsJapanese $originalTitle
     }
 }
@@ -287,8 +296,10 @@ foreach ($tconst in $candidates.Keys) {
     }
 }
 
-# Choose the best candidate per film: preferred title type, then most votes, then lowest tconst
+# Choose the best candidate per film: preferred title type, then most votes, then lowest tconst.
+# Keep the full ranked list (best first) so all candidates can be surfaced in the output.
 $bestImdbId = [System.Collections.Generic.Dictionary[object, string]]::new()
+$rankedByFilm = [System.Collections.Generic.Dictionary[object, object]]::new()
 foreach ($film in $filmCandidates.Keys) {
     # Wrap in @() so a single candidate isn't unwrapped (Sort-Object would otherwise return the
     # lone hashtable, whose .Count is its key count and whose [0] indexer is meaningless)
@@ -298,6 +309,7 @@ foreach ($film in $filmCandidates.Keys) {
         @{ Expression = { $_.tconst } })
     $best = $ranked[0]
     $bestImdbId[$film] = $best.tconst
+    $rankedByFilm[$film] = $ranked
 
     if ($ranked.Count -gt 1) {
         $alts = ($ranked | Select-Object -Skip 1 | ForEach-Object { "$($_.tconst) ($($_.data.titleType), $($_.data.votes) votes)" }) -join ', '
@@ -359,13 +371,24 @@ foreach ($film in $needsWikidata) {
     }
 
     if ($bestImdbId.ContainsKey($film)) {
-        $imdbId = $bestImdbId[$film]
-        $entry['imdb'] = [ordered]@{
-            id  = $imdbId
-            url = "https://www.imdb.com/title/$imdbId/"
+        $imdbList = [System.Collections.Generic.List[object]]::new()
+        foreach ($cand in $rankedByFilm[$film]) {
+            $imdbId = $cand.tconst
+            $item = [ordered]@{
+                title = [string]$cand.data.title
+                type  = [string]$cand.data.titleType
+            }
+            if ($null -ne $cand.data.year) {
+                $item['year'] = $cand.data.year
+            }
+            $item['id'] = $imdbId
+            $item['url'] = "https://www.imdb.com/title/$imdbId/"
+            $imdbList.Add($item)
         }
+        $entry['imdb'] = $imdbList
         $withImdb++
 
+        $imdbId = $bestImdbId[$film]
         if ($qidByImdbId.ContainsKey($imdbId)) {
             $qid = $qidByImdbId[$imdbId]
             $entry['wikidata'] = [ordered]@{

--- a/scripts/discover/films/SuggestWikidataIdentifiers.ps1
+++ b/scripts/discover/films/SuggestWikidataIdentifiers.ps1
@@ -59,14 +59,31 @@ function Invoke-WikidataSparql($query) {
     }
 }
 
-function Get-NormalizedTitle([string]$title) {
-    if ([string]::IsNullOrEmpty($title) -or $title -eq '\N') {
-        return $null
+# Title normalization runs once per row across the full IMDb akas/basics datasets (tens of
+# millions of calls). A PowerShell function call at that volume is ~10x slower than the work
+# itself, so the normalizer lives in a compiled helper invoked directly as a static method.
+Add-Type -TypeDefinition @'
+using System.Text;
+public static class TandokuTitle {
+    // Lower-cases, collapses runs of non-letter/non-digit characters to a single space, and trims.
+    public static string Normalize(string title) {
+        if (string.IsNullOrEmpty(title) || title == "\\N") return null;
+        var sb = new StringBuilder(title.Length);
+        bool pendingSpace = false, started = false;
+        foreach (char c in title) {
+            if (char.IsLetterOrDigit(c)) {
+                if (pendingSpace && started) sb.Append(' ');
+                sb.Append(char.ToLowerInvariant(c));
+                started = true;
+                pendingSpace = false;
+            } else {
+                pendingSpace = true;
+            }
+        }
+        return sb.ToString();
     }
-    $n = $title.ToLowerInvariant()
-    $n = [regex]::Replace($n, '[^\p{L}\p{Nd}]+', ' ')
-    return $n.Trim()
 }
+'@
 
 # Japanese-language signal: title contains Hiragana, Katakana, or CJK ideographs
 $cjkRegex = [regex]::new('[\p{IsHiragana}\p{IsKatakana}\p{IsCJKUnifiedIdeographs}]')
@@ -92,7 +109,7 @@ $needsWikidata = [System.Collections.Generic.List[object]]::new()
 foreach ($film in $films) {
     if ($film.providers -and $film.providers.netflix -and $null -ne $film.providers.netflix.id -and -not $film.wikidata) {
         $needsWikidata.Add($film)
-        $norm = Get-NormalizedTitle ([string]$film.providers.netflix.title)
+        $norm = [TandokuTitle]::Normalize([string]$film.providers.netflix.title)
         if ($norm) {
             if (-not $filmsByTitle.ContainsKey($norm)) {
                 $filmsByTitle[$norm] = [System.Collections.Generic.List[object]]::new()
@@ -191,7 +208,7 @@ foreach ($line in [System.IO.File]::ReadLines($akasPath)) {
     $title = $fields[2]
     $groupTitles.Add($title)
     if ($fields.Count -ge 5 -and $fields[4] -eq 'ja') { $groupHasJaLang = $true }
-    $norm = Get-NormalizedTitle $title
+    $norm = [TandokuTitle]::Normalize($title)
     if ($norm -and $filmsByTitle.ContainsKey($norm)) {
         if (-not $groupFilms) { $groupFilms = [System.Collections.Generic.Dictionary[object, object]]::new() }
         foreach ($f in $filmsByTitle[$norm]) { $groupFilms[$f] = $true }
@@ -225,7 +242,7 @@ foreach ($line in [System.IO.File]::ReadLines($basicsPath)) {
     $originalTitle = $fields[3]
 
     foreach ($t in @($primaryTitle, $originalTitle)) {
-        $norm = Get-NormalizedTitle $t
+        $norm = [TandokuTitle]::Normalize($t)
         if ($norm -and $filmsByTitle.ContainsKey($norm)) {
             Add-Candidate $tconst $filmsByTitle[$norm]
         }

--- a/scripts/discover/films/SuggestWikidataIdentifiers.ps1
+++ b/scripts/discover/films/SuggestWikidataIdentifiers.ps1
@@ -1,0 +1,367 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$DatabasePath,
+
+    [Parameter(Mandatory)]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [string]$ImdbDataPath = (Join-Path ([IO.Path]::GetTempPath()) 'tandoku-imdb'),
+
+    [switch]$UpdateImdbData
+)
+
+Import-Module "$PSScriptRoot/../../modules/tandoku-yaml.psm1"
+
+$sparqlHeaders = @{ "User-Agent" = "tandoku-discover/1.0 (https://github.com/tandoku)" }
+
+# IMDb title types that represent watchable films / series (excludes tvEpisode, videoGame, etc.)
+$allowedTitleTypes = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]@('movie', 'tvMovie', 'tvSeries', 'tvMiniSeries', 'short', 'tvShort', 'tvSpecial', 'video'))
+
+# Rank of title type when choosing between multiple candidates (lower = preferred)
+$titleTypeRank = @{
+    movie        = 0
+    tvSeries     = 0
+    tvMiniSeries = 0
+    tvMovie      = 1
+    tvSpecial    = 2
+    video        = 3
+    short        = 4
+    tvShort      = 4
+}
+
+function Invoke-WikidataSparql($query) {
+    $url = "https://query.wikidata.org/sparql?query=$([uri]::EscapeDataString($query))&format=json"
+    $maxRetries = 3
+    for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
+        try {
+            return (Invoke-RestMethod -Uri $url -Headers $sparqlHeaders).results.bindings
+        }
+        catch {
+            $retrySeconds = 0
+            if ($_.Exception.Response.StatusCode -eq 429 -or $_ -match '429') {
+                if ($_ -match 'retry in (\d+) seconds') {
+                    $retrySeconds = [int]$Matches[1]
+                } else {
+                    $retrySeconds = 120
+                }
+            }
+
+            if ($retrySeconds -gt 0 -and $attempt -lt $maxRetries) {
+                Write-Warning "Rate limited (429) - waiting $retrySeconds seconds before retry $attempt/$maxRetries..."
+                Start-Sleep -Seconds $retrySeconds
+            } else {
+                throw
+            }
+        }
+    }
+}
+
+function Get-NormalizedTitle([string]$title) {
+    if ([string]::IsNullOrEmpty($title) -or $title -eq '\N') {
+        return $null
+    }
+    $n = $title.ToLowerInvariant()
+    $n = [regex]::Replace($n, '[^\p{L}\p{Nd}]+', ' ')
+    return $n.Trim()
+}
+
+# Japanese-language signal: title contains Hiragana, Katakana, or CJK ideographs
+$cjkRegex = [regex]::new('[\p{IsHiragana}\p{IsKatakana}\p{IsCJKUnifiedIdeographs}]')
+function Test-ContainsJapanese([string]$title) {
+    if ([string]::IsNullOrEmpty($title) -or $title -eq '\N') {
+        return $false
+    }
+    return $cjkRegex.IsMatch($title)
+}
+
+# --- Read films database, collect entries that need a Wikidata identifier ---
+
+$films = [System.Collections.Generic.List[object]]::new()
+foreach ($doc in @(Import-Yaml -LiteralPath $DatabasePath)) {
+    $films.Add($doc)
+}
+
+Write-Host "Read $($films.Count) entries from films database"
+
+# Map normalized Netflix title -> list of films missing wikidata (a title may map to several films)
+$filmsByTitle = @{}
+$needsWikidata = [System.Collections.Generic.List[object]]::new()
+foreach ($film in $films) {
+    if ($film.providers -and $film.providers.netflix -and $null -ne $film.providers.netflix.id -and -not $film.wikidata) {
+        $needsWikidata.Add($film)
+        $norm = Get-NormalizedTitle ([string]$film.providers.netflix.title)
+        if ($norm) {
+            if (-not $filmsByTitle.ContainsKey($norm)) {
+                $filmsByTitle[$norm] = [System.Collections.Generic.List[object]]::new()
+            }
+            $filmsByTitle[$norm].Add($film)
+        }
+    }
+}
+
+Write-Host "$($needsWikidata.Count) entries missing Wikidata identifier (with Netflix info)"
+
+foreach ($norm in $filmsByTitle.Keys) {
+    if ($filmsByTitle[$norm].Count -gt 1) {
+        $ids = ($filmsByTitle[$norm] | ForEach-Object { $_.providers.netflix.id }) -join ', '
+        Write-Warning "Multiple films share normalized title '$norm' (Netflix IDs: $ids); IMDb matches will apply to all of them"
+    }
+}
+
+if ($needsWikidata.Count -eq 0) {
+    Write-Host "Nothing to do"
+    @() | Export-Yaml -Path $OutputPath
+    return
+}
+
+# --- Download IMDb datasets ---
+
+$imdbData = & "$PSScriptRoot/UpdateIMDbData.ps1" `
+    -ImdbDataPath $ImdbDataPath `
+    -Datasets 'title.akas', 'title.basics', 'title.ratings' `
+    -UpdateImdbData:$UpdateImdbData
+
+# Candidate IMDb titles keyed by tconst.
+#   films          = set of Netflix films this tconst was title-matched to
+#   titleType      = IMDb title type (from basics)
+#   japaneseAka    = has an alternate title in Japanese (language 'ja' or CJK text)
+#   japaneseOrig   = basics originalTitle contains Japanese text
+#   votes          = IMDb vote count (tie-breaker)
+$candidates = @{}
+
+function Add-Candidate([string]$tconst, $matchedFilms) {
+    if (-not $candidates.ContainsKey($tconst)) {
+        $candidates[$tconst] = [ordered]@{
+            films        = [System.Collections.Generic.Dictionary[object, object]]::new()
+            titleType    = $null
+            japaneseAka  = $false
+            japaneseOrig = $false
+            votes        = 0
+        }
+    }
+    foreach ($film in $matchedFilms) {
+        $candidates[$tconst].films[$film] = $true
+    }
+}
+
+# --- Pass 1: title.akas - match alternate titles to needed Netflix titles ---
+#
+# Rows for a given titleId are contiguous in the file, so we accumulate each group and, on
+# encountering a new titleId, decide whether the group title-matched any needed film and whether
+# any of its alternate titles is Japanese (a far stronger origin signal than the matched English
+# title alone, e.g. the Japanese-language aka can appear in a different row than the match).
+
+Write-Host "Scanning IMDb akas for title matches..."
+$akasPath = $imdbData['title.akas']
+$lineCount = 0
+$groupTconst = $null
+$groupFilms = $null
+$groupTitles = [System.Collections.Generic.List[string]]::new()
+$groupHasJaLang = $false
+foreach ($line in [System.IO.File]::ReadLines($akasPath)) {
+    $lineCount++
+    if ($lineCount -eq 1) { continue } # header
+    # titleId, ordering, title, region, language, ...
+    $fields = $line.Split("`t", 5)
+    if ($fields.Count -lt 3) { continue }
+    $tconst = $fields[0]
+
+    if ($tconst -ne $groupTconst) {
+        # Flush previous group; evaluate the (relatively expensive) Japanese-script test only for
+        # groups that actually matched a needed film, keeping the per-row work cheap.
+        if ($groupFilms -and $groupFilms.Count -gt 0) {
+            $hasJa = $groupHasJaLang
+            if (-not $hasJa) {
+                foreach ($t in $groupTitles) {
+                    if (Test-ContainsJapanese $t) { $hasJa = $true; break }
+                }
+            }
+            Add-Candidate $groupTconst @($groupFilms.Keys)
+            $candidates[$groupTconst].japaneseAka = $hasJa
+        }
+        $groupTconst = $tconst
+        $groupFilms = $null
+        $groupTitles.Clear()
+        $groupHasJaLang = $false
+    }
+
+    $title = $fields[2]
+    $groupTitles.Add($title)
+    if ($fields.Count -ge 5 -and $fields[4] -eq 'ja') { $groupHasJaLang = $true }
+    $norm = Get-NormalizedTitle $title
+    if ($norm -and $filmsByTitle.ContainsKey($norm)) {
+        if (-not $groupFilms) { $groupFilms = [System.Collections.Generic.Dictionary[object, object]]::new() }
+        foreach ($f in $filmsByTitle[$norm]) { $groupFilms[$f] = $true }
+    }
+}
+if ($groupFilms -and $groupFilms.Count -gt 0) {
+    $hasJa = $groupHasJaLang
+    if (-not $hasJa) {
+        foreach ($t in $groupTitles) {
+            if (Test-ContainsJapanese $t) { $hasJa = $true; break }
+        }
+    }
+    Add-Candidate $groupTconst @($groupFilms.Keys)
+    $candidates[$groupTconst].japaneseAka = $hasJa
+}
+Write-Host "akas matches: $($candidates.Count) candidate IMDb titles"
+
+# --- Pass 2: title.basics - match primary/original titles, record type + japanese signal ---
+
+Write-Host "Scanning IMDb basics for title matches and metadata..."
+$basicsPath = $imdbData['title.basics']
+$lineCount = 0
+foreach ($line in [System.IO.File]::ReadLines($basicsPath)) {
+    $lineCount++
+    if ($lineCount -eq 1) { continue } # header
+    # tconst, titleType, primaryTitle, originalTitle, ...
+    $fields = $line.Split("`t", 5)
+    if ($fields.Count -lt 4) { continue }
+    $tconst = $fields[0]
+    $primaryTitle = $fields[2]
+    $originalTitle = $fields[3]
+
+    foreach ($t in @($primaryTitle, $originalTitle)) {
+        $norm = Get-NormalizedTitle $t
+        if ($norm -and $filmsByTitle.ContainsKey($norm)) {
+            Add-Candidate $tconst $filmsByTitle[$norm]
+        }
+    }
+
+    if ($candidates.ContainsKey($tconst)) {
+        $candidates[$tconst].titleType = $fields[1]
+        $candidates[$tconst].japaneseOrig = Test-ContainsJapanese $originalTitle
+    }
+}
+Write-Host "After basics: $($candidates.Count) candidate IMDb titles"
+
+# --- Pass 3: title.ratings - votes for tie-breaking ---
+
+Write-Host "Scanning IMDb ratings for vote counts..."
+$ratingsPath = $imdbData['title.ratings']
+$lineCount = 0
+foreach ($line in [System.IO.File]::ReadLines($ratingsPath)) {
+    $lineCount++
+    if ($lineCount -eq 1) { continue } # header
+    # tconst, averageRating, numVotes
+    $fields = $line.Split("`t", 4)
+    if ($fields.Count -lt 3) { continue }
+    if ($candidates.ContainsKey($fields[0])) {
+        $candidates[$fields[0]].votes = [int]$fields[2]
+    }
+}
+
+# --- Filter candidates and assign best IMDb match per film ---
+
+# Invert: Netflix film -> list of surviving candidate tconsts
+$filmCandidates = [System.Collections.Generic.Dictionary[object, object]]::new()
+foreach ($tconst in $candidates.Keys) {
+    $c = $candidates[$tconst]
+    if (-not $allowedTitleTypes.Contains([string]$c.titleType)) { continue }
+    if (-not ($c.japaneseAka -or $c.japaneseOrig)) { continue }
+    foreach ($film in $c.films.Keys) {
+        if (-not $filmCandidates.ContainsKey($film)) {
+            $filmCandidates[$film] = [System.Collections.Generic.List[object]]::new()
+        }
+        $filmCandidates[$film].Add(@{ tconst = $tconst; data = $c })
+    }
+}
+
+# Choose the best candidate per film: preferred title type, then most votes, then lowest tconst
+$bestImdbId = [System.Collections.Generic.Dictionary[object, string]]::new()
+foreach ($film in $filmCandidates.Keys) {
+    # Wrap in @() so a single candidate isn't unwrapped (Sort-Object would otherwise return the
+    # lone hashtable, whose .Count is its key count and whose [0] indexer is meaningless)
+    $ranked = @($filmCandidates[$film] | Sort-Object `
+        @{ Expression = { if ($titleTypeRank.ContainsKey([string]$_.data.titleType)) { $titleTypeRank[[string]$_.data.titleType] } else { 99 } } }, `
+        @{ Expression = { $_.data.votes }; Descending = $true }, `
+        @{ Expression = { $_.tconst } })
+    $best = $ranked[0]
+    $bestImdbId[$film] = $best.tconst
+
+    if ($ranked.Count -gt 1) {
+        $alts = ($ranked | Select-Object -Skip 1 | ForEach-Object { "$($_.tconst) ($($_.data.titleType), $($_.data.votes) votes)" }) -join ', '
+        Write-Warning "Netflix '$($film.providers.netflix.title)' ($($film.providers.netflix.id)) -> $($best.tconst); other candidates: $alts"
+    }
+}
+
+Write-Host "Found IMDb candidates for $($bestImdbId.Count)/$($needsWikidata.Count) films"
+
+# --- Look up existing Wikidata entities for the matched IMDb IDs (P345) ---
+
+$imdbIds = @($bestImdbId.Values | Sort-Object -Unique)
+$qidByImdbId = @{}
+if ($imdbIds.Count -gt 0) {
+    Write-Host "Querying Wikidata for $($imdbIds.Count) IMDb IDs..."
+    $batchSize = 50
+    for ($i = 0; $i -lt $imdbIds.Count; $i += $batchSize) {
+        $end = [Math]::Min($i + $batchSize - 1, $imdbIds.Count - 1)
+        $batch = $imdbIds[$i..$end]
+        $values = ($batch | ForEach-Object { "`"$_`"" }) -join " "
+        $query = "SELECT ?item ?imdbId WHERE { VALUES ?imdbId { $values } ?item wdt:P345 ?imdbId . }"
+
+        try {
+            foreach ($binding in (Invoke-WikidataSparql $query)) {
+                $qid = $binding.item.value -replace '.*/entity/', ''
+                $imdbId = $binding.imdbId.value
+                if (-not $qidByImdbId.ContainsKey($imdbId)) {
+                    $qidByImdbId[$imdbId] = $qid
+                } elseif ($qidByImdbId[$imdbId] -ne $qid) {
+                    Write-Warning "IMDb ID $imdbId matches multiple Wikidata entities: $($qidByImdbId[$imdbId]), $qid (keeping first)"
+                }
+            }
+        }
+        catch {
+            Write-Warning "Failed to query Wikidata for batch at index ${i}: $_"
+        }
+
+        Write-Host "Wikidata lookup: $([Math]::Min($i + $batchSize, $imdbIds.Count))/$($imdbIds.Count)"
+
+        if ($i + $batchSize -lt $imdbIds.Count) {
+            Start-Sleep -Milliseconds 1000
+        }
+    }
+}
+
+# --- Write candidates to output ---
+
+$results = [System.Collections.Generic.List[object]]::new()
+$withImdb = 0
+$withWikidata = 0
+foreach ($film in $needsWikidata) {
+    $netflixId = $film.providers.netflix.id
+    $entry = [ordered]@{
+        netflix = [ordered]@{
+            id  = $netflixId
+            url = "https://www.netflix.com/title/$netflixId"
+        }
+    }
+
+    if ($bestImdbId.ContainsKey($film)) {
+        $imdbId = $bestImdbId[$film]
+        $entry['imdb'] = [ordered]@{
+            id  = $imdbId
+            url = "https://www.imdb.com/title/$imdbId/"
+        }
+        $withImdb++
+
+        if ($qidByImdbId.ContainsKey($imdbId)) {
+            $qid = $qidByImdbId[$imdbId]
+            $entry['wikidata'] = [ordered]@{
+                id  = $qid
+                url = "https://www.wikidata.org/wiki/$qid"
+            }
+            $withWikidata++
+        }
+    }
+
+    $results.Add($entry)
+}
+
+$results | Export-Yaml -Path $OutputPath
+
+Write-Host "Done - wrote $($results.Count) candidates to $OutputPath"
+Write-Host "  $withImdb with IMDb match, $withWikidata with existing Wikidata entity"

--- a/scripts/discover/films/SuggestWikidataIdentifiers.ps1
+++ b/scripts/discover/films/SuggestWikidataIdentifiers.ps1
@@ -352,8 +352,9 @@ foreach ($film in $needsWikidata) {
     $netflixId = $film.providers.netflix.id
     $entry = [ordered]@{
         netflix = [ordered]@{
-            id  = $netflixId
-            url = "https://www.netflix.com/title/$netflixId"
+            title = [string]$film.providers.netflix.title
+            id    = $netflixId
+            url   = "https://www.netflix.com/title/$netflixId"
         }
     }
 
@@ -374,6 +375,8 @@ foreach ($film in $needsWikidata) {
             $withWikidata++
         }
     }
+
+    $entry['verified'] = $false
 
     $results.Add($entry)
 }

--- a/scripts/discover/films/SuggestWikidataIdentifiers.ps1
+++ b/scripts/discover/films/SuggestWikidataIdentifiers.ps1
@@ -6,8 +6,8 @@ param(
     [Parameter(Mandatory)]
     [string]$OutputPath,
 
-    [Parameter()]
-    [string]$ImdbDataPath = (Join-Path ([IO.Path]::GetTempPath()) 'tandoku-imdb'),
+    [Parameter(Mandatory)]
+    [string]$ImdbDataPath,
 
     [switch]$UpdateImdbData
 )

--- a/scripts/discover/films/UpdateIMDbData.ps1
+++ b/scripts/discover/films/UpdateIMDbData.ps1
@@ -1,0 +1,51 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ImdbDataPath,
+
+    [Parameter()]
+    [string[]]$Datasets = @('title.ratings'),
+
+    [switch]$UpdateImdbData
+)
+
+# Downloads the requested IMDb datasets (https://datasets.imdbws.com) into $ImdbDataPath,
+# extracting each `<dataset>.tsv.gz` to `<dataset>.tsv`. Returns an ordered hashtable mapping
+# each dataset name to the path of its extracted .tsv file. Existing .tsv files are reused
+# unless -UpdateImdbData is specified.
+
+if (-not (Test-Path $ImdbDataPath)) {
+    New-Item -ItemType Directory -Path $ImdbDataPath | Out-Null
+}
+
+$ImdbDataPath = (Resolve-Path $ImdbDataPath).Path
+
+$result = [ordered]@{}
+foreach ($dataset in $Datasets) {
+    $gzPath = Join-Path $ImdbDataPath "$dataset.tsv.gz"
+    $tsvPath = Join-Path $ImdbDataPath "$dataset.tsv"
+
+    if ($UpdateImdbData -or -not (Test-Path $tsvPath)) {
+        if ($UpdateImdbData -or -not (Test-Path $gzPath)) {
+            $url = "https://datasets.imdbws.com/$dataset.tsv.gz"
+            Write-Host "Downloading $url..."
+            Invoke-WebRequest -Uri $url -OutFile $gzPath
+        }
+
+        Write-Host "Extracting $dataset.tsv..."
+        # Extract to a temporary file first so an interrupted run never leaves a partial .tsv
+        $tmpPath = "$tsvPath.tmp"
+        $gzIn = [System.IO.File]::OpenRead($gzPath)
+        $gzStream = [System.IO.Compression.GZipStream]::new($gzIn, [System.IO.Compression.CompressionMode]::Decompress)
+        $tsvOut = [System.IO.File]::Create($tmpPath)
+        $gzStream.CopyTo($tsvOut)
+        $tsvOut.Close()
+        $gzStream.Close()
+        $gzIn.Close()
+        Move-Item -LiteralPath $tmpPath -Destination $tsvPath -Force
+    }
+
+    $result[$dataset] = $tsvPath
+}
+
+return $result

--- a/scripts/discover/films/UpdateIMDbData.ps1
+++ b/scripts/discover/films/UpdateIMDbData.ps1
@@ -3,8 +3,8 @@ param(
     [Parameter(Mandatory)]
     [string]$ImdbDataPath,
 
-    [Parameter()]
-    [string[]]$Datasets = @('title.ratings'),
+    [Parameter(Mandatory)]
+    [string[]]$Datasets,
 
     [switch]$UpdateImdbData
 )

--- a/scripts/discover/films/discover-films-spec.md
+++ b/scripts/discover/films/discover-films-spec.md
@@ -145,7 +145,7 @@ Uses `UpdateIMDbData.ps1` to fetch `title.akas`, `title.basics`, and `title.rati
 
 Candidate IMDb titles are kept when their `titleType` is a watchable type (`movie`, `tvMovie`, `tvSeries`, `tvMiniSeries`, `short`, `tvShort`, `tvSpecial`, `video`) **and** they carry a Japanese signal (from either the akas or the original title). For each film the best surviving candidate is chosen by preferred title type, then most votes, then lowest IMDb ID; a warning lists the alternatives whenever more than one candidate survives. The chosen IMDb IDs are then looked up on Wikidata in batches (property P345) to find any entity that already exists.
 
-Writes one YAML document per processed film to `-OutputPath`, omitting the `imdb` and/or `wikidata` sections when no match was found. Each document ends with `verified: false`, a placeholder for a future manual-review workflow:
+Writes one YAML document per processed film to `-OutputPath`. The `imdb` section is a list of all surviving candidates ordered the same way the best match is chosen (preferred title type, then most votes, then lowest IMDb ID), so the selected candidate is first; the `wikidata` section corresponds to that selected candidate. The `imdb` and/or `wikidata` sections are omitted when no match was found. Each document ends with `verified: false`, a placeholder for a future manual-review workflow:
 
 ```yaml
 netflix:
@@ -153,8 +153,12 @@ netflix:
   id: <netflix-id>
   url: <netflix-title-url>
 imdb:
-  id: <imdb-id>
-  url: <imdb-title-url>
+  - title: <imdb-title>
+    type: <imdb-title-type>
+    year: <imdb-start-year>
+    id: <imdb-id>
+    url: <imdb-title-url>
+  # ...additional candidates in ranked order
 wikidata:
   id: <wikidata-id>
   url: <wikidata-entity-url>

--- a/scripts/discover/films/discover-films-spec.md
+++ b/scripts/discover/films/discover-films-spec.md
@@ -125,13 +125,13 @@ Uses `UpdateIMDbData.ps1` to download `title.ratings.tsv.gz` from IMDb daily dat
 ## SuggestWikidataIdentifiers.ps1
 ### Usage
 ```powershell
-SuggestWikidataIdentifiers.ps1 -DatabasePath <films.yaml> -OutputPath <candidates.yaml> [-ImdbDataPath <path>] [-UpdateImdbData]
+SuggestWikidataIdentifiers.ps1 -DatabasePath <films.yaml> -OutputPath <candidates.yaml> -ImdbDataPath <path> [-UpdateImdbData]
 ```
 
 ### Parameters
 - `-DatabasePath` - Path to the films.yaml database file.
 - `-OutputPath` - Path to the YAML file to write proposed candidates to.
-- `-ImdbDataPath` - Path to a local folder for storing IMDb data files downloaded from https://datasets.imdbws.com. Defaults to a `tandoku-imdb` folder under the system temp directory.
+- `-ImdbDataPath` - Path to a local folder for storing IMDb data files downloaded from https://datasets.imdbws.com.
 - `-UpdateImdbData` - When specified, re-downloads IMDb data files even if they already exist locally.
 
 ### Behavior

--- a/scripts/discover/films/discover-films-spec.md
+++ b/scripts/discover/films/discover-films-spec.md
@@ -145,10 +145,11 @@ Uses `UpdateIMDbData.ps1` to fetch `title.akas`, `title.basics`, and `title.rati
 
 Candidate IMDb titles are kept when their `titleType` is a watchable type (`movie`, `tvMovie`, `tvSeries`, `tvMiniSeries`, `short`, `tvShort`, `tvSpecial`, `video`) **and** they carry a Japanese signal (from either the akas or the original title). For each film the best surviving candidate is chosen by preferred title type, then most votes, then lowest IMDb ID; a warning lists the alternatives whenever more than one candidate survives. The chosen IMDb IDs are then looked up on Wikidata in batches (property P345) to find any entity that already exists.
 
-Writes one YAML document per processed film to `-OutputPath`, omitting the `imdb` and/or `wikidata` sections when no match was found:
+Writes one YAML document per processed film to `-OutputPath`, omitting the `imdb` and/or `wikidata` sections when no match was found. Each document ends with `verified: false`, a placeholder for a future manual-review workflow:
 
 ```yaml
 netflix:
+  title: <netflix-title>
   id: <netflix-id>
   url: <netflix-title-url>
 imdb:
@@ -157,6 +158,7 @@ imdb:
 wikidata:
   id: <wikidata-id>
   url: <wikidata-entity-url>
+verified: false
 ---
 # one document per film in YAML stream
 ```

--- a/scripts/discover/films/discover-films-spec.md
+++ b/scripts/discover/films/discover-films-spec.md
@@ -168,6 +168,31 @@ verified: false
 ```
 
 
+## CommitWikidataIdentifiers.ps1
+### Usage
+```powershell
+CommitWikidataIdentifiers.ps1 -CandidatesPath <candidates.yaml> [-AccessToken <token>] [-ApiUrl <url>] [-WhatIf]
+```
+
+### Parameters
+- `-CandidatesPath` - Path to the candidates YAML stream produced by `SuggestWikidataIdentifiers.ps1` (after manual review).
+- `-AccessToken` - Wikidata OAuth 2.0 owner-only access token used to authenticate edits. Falls back to the `WIKIDATA_ACCESS_TOKEN` environment variable. Only required when actually writing (not needed with `-WhatIf`).
+- `-ApiUrl` - Wikidata Action API endpoint. Defaults to `https://www.wikidata.org/w/api.php`.
+- `-WhatIf` - Previews the claims that would be added without making any edits (and without requiring a token).
+
+### Behavior
+Reads the candidates YAML and writes Netflix ID (P1874) and IMDb ID (P345) claims to the corresponding Wikidata entities. Only `netflix.id`, `imdb.id`, and `wikidata.id` are used; all other fields are ignored apart from the `verified` flag.
+
+Each document is processed as follows:
+- Documents without `verified: true` are ignored.
+- A valid `wikidata.id` (`Q`-number) is required; the record is skipped with a warning otherwise.
+- A record with more than one `imdb` entry is skipped with a warning - the reviewer is expected to remove the incorrect entries first. A record with a single `imdb` entry contributes its `imdb.id` (validated as `tt`-number); a record with no `imdb` entry commits only the Netflix ID.
+- Existing P345/P1874 claims on the entity are read first (a public, unauthenticated request). If the entity already has an IMDb **or** Netflix ID that does not match the candidate, the whole record is skipped with a warning, since a mismatching identifier means the `wikidata.id` mapping is suspect.
+- Only missing claims are added, so re-running the script is idempotent. A record whose identifiers are already present is reported as up to date.
+
+Writes use the Action API (`wbcreateclaim`) with `assert=user` and `maxlag=5` (retrying on replication lag); a CSRF token is fetched lazily only when an edit is actually performed. Per-record failures are reported individually so a partial update (e.g. Netflix written but IMDb failed) is visible and corrected on the next run.
+
+
 ## PopulateNatively.ps1
 ### Usage
 ```powershell

--- a/scripts/discover/films/discover-films-spec.md
+++ b/scripts/discover/films/discover-films-spec.md
@@ -97,12 +97,12 @@ Iterates over each entry in films.yaml and populates data from Wikidata in two p
 ## UpdateIMDbData.ps1
 ### Usage
 ```powershell
-UpdateIMDbData.ps1 -ImdbDataPath <path> [-Datasets <names>] [-UpdateImdbData]
+UpdateIMDbData.ps1 -ImdbDataPath <path> -Datasets <names> [-UpdateImdbData]
 ```
 
 ### Parameters
 - `-ImdbDataPath` - Path to a local folder for storing IMDb data files downloaded from https://datasets.imdbws.com.
-- `-Datasets` - One or more IMDb dataset names to make available, given without the `.tsv.gz` suffix (e.g. `title.ratings`, `title.basics`, `title.akas`). Defaults to `title.ratings`.
+- `-Datasets` - One or more IMDb dataset names to make available, given without the `.tsv.gz` suffix (e.g. `title.ratings`, `title.basics`, `title.akas`).
 - `-UpdateImdbData` - When specified, re-downloads (and re-extracts) the data files even if they already exist locally.
 
 ### Behavior

--- a/scripts/discover/films/discover-films-spec.md
+++ b/scripts/discover/films/discover-films-spec.md
@@ -94,6 +94,20 @@ Iterates over each entry in films.yaml and populates data from Wikidata in two p
 1. **QID lookup** - For entries missing the `wikidata` field that have `providers.netflix.id`, looks up the Wikidata entity ID associated with the Netflix ID (using Wikidata property P1874). With `-Force`, re-resolves the QID for every entry that has a Netflix ID.
 2. **Details enrichment** - For entries that have a `wikidata` QID but are missing a `title`, queries Wikidata to populate additional fields: `title` (English label), `title-ja` (Japanese label), `type` (instance of / P31, kebab-cased, as a list of all values), `originCountry` (country of origin / P495, as a list of all values), `originalLanguage` (original language codes / P364 + P424, as a list of all values), `year` (start time / P580, or publication date / P577), `imdb.id` (P345), `myAnimeList.id` (P4086), `tmdb.id` (TMDb movie P4947 or TV series P4983), and `tmdb.kind` (`movie` or `tv-series` to disambiguate the TMDb ID). When Wikidata returns multiple IDs for `imdb.id`, `myAnimeList.id`, or `tmdb.id`, the script warns and keeps the lowest value for stability; for `tmdb.id` it prefers a TV series ID over a movie ID (warning also when both movie and TV IDs are present). With `-Force`, enriches every entry that has a QID and overwrites each field, removing any field for which Wikidata no longer returns a value.
 
+## UpdateIMDbData.ps1
+### Usage
+```powershell
+UpdateIMDbData.ps1 -ImdbDataPath <path> [-Datasets <names>] [-UpdateImdbData]
+```
+
+### Parameters
+- `-ImdbDataPath` - Path to a local folder for storing IMDb data files downloaded from https://datasets.imdbws.com.
+- `-Datasets` - One or more IMDb dataset names to make available, given without the `.tsv.gz` suffix (e.g. `title.ratings`, `title.basics`, `title.akas`). Defaults to `title.ratings`.
+- `-UpdateImdbData` - When specified, re-downloads (and re-extracts) the data files even if they already exist locally.
+
+### Behavior
+Shared helper used by the other IMDb-consuming scripts. For each requested dataset, downloads `<dataset>.tsv.gz` from the IMDb daily data dumps into `-ImdbDataPath` and extracts it to `<dataset>.tsv`. Existing `.tsv` files are reused unless `-UpdateImdbData` is specified; a previously downloaded `.gz` is reused (and only re-extracted) when its `.tsv` is missing. Extraction is written to a temporary file and moved into place so an interrupted run never leaves a partial `.tsv`. Returns an ordered hashtable mapping each dataset name to the full path of its extracted `.tsv` file.
+
 ## PopulateIMDb.ps1
 ### Usage
 ```powershell
@@ -106,7 +120,47 @@ PopulateIMDb.ps1 -DatabasePath <films.yaml> -ImdbDataPath <path> [-UpdateImdbDat
 - `-UpdateImdbData` - When specified, re-downloads IMDb data files even if they already exist locally.
 
 ### Behavior
-Downloads `title.ratings.tsv.gz` from IMDb daily data dumps and extracts it to the folder specified by `-ImdbDataPath`. Uses existing data files at that path unless `-UpdateImdbData` is specified. For each entry in films.yaml that has `imdb.id`, looks up the IMDb rating and vote count and updates the `imdb.rating` and `imdb.votes` fields.
+Uses `UpdateIMDbData.ps1` to download `title.ratings.tsv.gz` from IMDb daily data dumps and extract it to the folder specified by `-ImdbDataPath` (passing through `-UpdateImdbData`). For each entry in films.yaml that has `imdb.id`, looks up the IMDb rating and vote count and updates the `imdb.rating` and `imdb.votes` fields.
+
+## SuggestWikidataIdentifiers.ps1
+### Usage
+```powershell
+SuggestWikidataIdentifiers.ps1 -DatabasePath <films.yaml> -OutputPath <candidates.yaml> [-ImdbDataPath <path>] [-UpdateImdbData]
+```
+
+### Parameters
+- `-DatabasePath` - Path to the films.yaml database file.
+- `-OutputPath` - Path to the YAML file to write proposed candidates to.
+- `-ImdbDataPath` - Path to a local folder for storing IMDb data files downloaded from https://datasets.imdbws.com. Defaults to a `tandoku-imdb` folder under the system temp directory.
+- `-UpdateImdbData` - When specified, re-downloads IMDb data files even if they already exist locally.
+
+### Behavior
+Proposes candidates for filling Wikidata data gaps. Considers every entry in films.yaml that has `providers.netflix.id` but no `wikidata` field, indexing them by a normalized form of `providers.netflix.title` (lower-cased, runs of non-letter/non-digit characters collapsed to a single space, trimmed); a warning is emitted when several films share the same normalized title.
+
+Uses `UpdateIMDbData.ps1` to fetch `title.akas`, `title.basics`, and `title.ratings`, then makes one streaming pass over each:
+
+1. **akas** - alternate titles are grouped by `titleId` (rows for a title are contiguous in the file); a title is a candidate when any of its alternate titles matches a needed Netflix title. While scanning the group it also records a Japanese-language signal (an alternate title tagged language `ja`, or one containing Hiragana/Katakana/Han characters) - this catches Japanese works whose matched title is the English/romaji one while the Japanese title appears in a separate row.
+2. **basics** - additionally matches each title's `primaryTitle`/`originalTitle`, and for every candidate records its `titleType` and whether its `originalTitle` contains Japanese text.
+3. **ratings** - records vote counts for candidate titles (used only as a tie-breaker).
+
+Candidate IMDb titles are kept when their `titleType` is a watchable type (`movie`, `tvMovie`, `tvSeries`, `tvMiniSeries`, `short`, `tvShort`, `tvSpecial`, `video`) **and** they carry a Japanese signal (from either the akas or the original title). For each film the best surviving candidate is chosen by preferred title type, then most votes, then lowest IMDb ID; a warning lists the alternatives whenever more than one candidate survives. The chosen IMDb IDs are then looked up on Wikidata in batches (property P345) to find any entity that already exists.
+
+Writes one YAML document per processed film to `-OutputPath`, omitting the `imdb` and/or `wikidata` sections when no match was found:
+
+```yaml
+netflix:
+  id: <netflix-id>
+  url: <netflix-title-url>
+imdb:
+  id: <imdb-id>
+  url: <imdb-title-url>
+wikidata:
+  id: <wikidata-id>
+  url: <wikidata-entity-url>
+---
+# one document per film in YAML stream
+```
+
 
 ## PopulateNatively.ps1
 ### Usage


### PR DESCRIPTION
## Why

Many films in the discover database have Netflix info but are missing a Wikidata identifier, which blocks further enrichment. This adds a prototype pipeline to find IMDb/Wikidata candidates for those gaps and, after manual review, write the confirmed identifiers back to Wikidata.

## What

Three new PowerShell scripts under `scripts/discover/films/`, plus a refactor and spec updates:

- **`UpdateIMDbData.ps1`** - reusable IMDb dataset download/extract helper (atomic extraction, selectable datasets). `PopulateIMDb.ps1` is refactored to use it so the download logic lives in one place and can be extended with additional datasets.
- **`SuggestWikidataIdentifiers.ps1`** - for each film with a Netflix ID but no `wikidata` field, matches it against IMDb `title.akas`/`title.basics`/`title.ratings`, applies Japanese-content and title-type filters, ranks candidates, looks up existing Wikidata entities by IMDb ID (P345), and writes one YAML document per film. The `imdb` section is a ranked candidate list (selected match first) and each document ends with `verified: false` for a future review step. Against the real database this finds IMDb candidates for 68/70 missing-Wikidata films (53 already have a Wikidata entity).
- **`CommitWikidataIdentifiers.ps1`** - reads the reviewed candidates YAML and writes Netflix (P1874) and IMDb (P345) IDs to Wikidata, but only for records marked `verified: true`, using just the `netflix.id`/`imdb.id`/`wikidata.id` fields.

## Notes for reviewers

- **Performance:** the suggestion script makes streaming passes over multi-GB IMDb TSVs. Per-row title normalization is done with a compiled C# helper via `Add-Type`, since PowerShell function-call overhead dominated at tens of millions of rows (runtime dropped from ~9m to ~2m30s).
- **Safety in the commit script:** it skips any record with multiple IMDb entries (reviewer must trim first) and skips the whole record if the entity already has a non-matching IMDb *or* Netflix ID, since a mismatch means the `wikidata.id` mapping is suspect. Writes are idempotent (only missing claims added), use `assert=user` + `maxlag=5` with retry, and the CSRF token is fetched lazily so `-WhatIf` works without a token. Reads are public and never send the access token.
- These are prototypes in the `scripts/` tree (the established pattern for this area), not part of the .NET solution.

`discover-films-spec.md` documents all three scripts.